### PR TITLE
Fix bump destinations and version ordering

### DIFF
--- a/.github/workflows/lint-buildfiles.yml
+++ b/.github/workflows/lint-buildfiles.yml
@@ -47,6 +47,8 @@ jobs:
       - name: shellcheck
         run: |
           find scripts -name '*.sh' -print0 | xargs -0 -n1 shellcheck -S warning
+      - name: manifest path + version-ordering tests
+        run: python3 scripts/test_layout.py
       - name: manifest sanity
         run: |
           yq -o=json '.tools' tools.yaml > /dev/null

--- a/.github/workflows/upstream-bump.yml
+++ b/.github/workflows/upstream-bump.yml
@@ -116,10 +116,20 @@ jobs:
         with:
           name: outdated
           path: .
+      # A bot PR does not trigger lint-buildfiles (its checks sit in
+      # action_required), so the bump validates its own tree here instead.
+      - name: manifest path + version-ordering tests
+        run: python3 scripts/test_layout.py
       - name: assemble bump
         run: |
           set -euo pipefail
           ./scripts/apply_bump.sh outdated.json dist bumped.json
+      - name: verify only binaries moved
+        run: |
+          set -euo pipefail
+          DOCS=$(git diff --name-only -- x64 arm | grep -E '\.(md|txt|conf|ya?ml|json)$' || true)
+          [ -z "$DOCS" ] || { echo "bump wrote over documentation:"; echo "$DOCS"; exit 1; }
+          python3 scripts/test_layout.py
       - name: open PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/apply_bump.sh
+++ b/scripts/apply_bump.sh
@@ -83,7 +83,8 @@ while [ $i -lt $N ]; do
 done
 
 if [ -n "$BUMPED" ]; then
-    # shellcheck disable=SC2086 -- BUMPED is a space-separated NAME=VER list
+    # BUMPED is a space-separated NAME=VER list; word splitting is intended
+    # shellcheck disable=SC2086
     python3 scripts/update_readme.py $BUMPED
 fi
 

--- a/scripts/apply_bump.sh
+++ b/scripts/apply_bump.sh
@@ -4,8 +4,7 @@
 # usage: scripts/apply_bump.sh <outdated.json> <dist-root> [bumped.json]
 #
 # For every outdated tool with artifacts under <dist-root>/bt-<tool>/:
-#   - copies binaries into their existing repo locations (found via git ls-files,
-#     falling back to x64/<bin> / arm/<bin> for new files)
+#   - copies binaries to the paths tools.yaml declares (outputs[].dst)
 #   - bumps `version` in tools.yaml
 #   - records the bump in bumped.json (only tools that actually built+tested)
 # Then regenerates README rows via scripts/update_readme.py.
@@ -17,6 +16,37 @@ BUMPED_OUT=${3:-bumped.json}
 YQ=$(command -v yq || echo /opt/toolbelt/yq)
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$ROOT"
+
+# Destinations come from tools.yaml alone. They used to be searched for with
+# `git ls-files "x64/**/$BIN" "x64/$BIN"`, but the second pathspec matches a
+# whole directory: for BIN=tor git listed x64/tor/README.md first and the tor
+# binary was committed on top of its own documentation.
+dests() {
+    python3 "$ROOT/scripts/manifest.py" dests "$1" "$2"
+}
+
+is_elf() {
+    [ "$(head -c 4 "$1" | od -An -tx1 | tr -d ' \n')" = "7f454c46" ]
+}
+
+# Copy one arch's built binaries into the repo, refusing to overwrite anything
+# that is not already a binary.
+install_arch() {
+    local tool=$1 arch=$2 srcdir=$3 bin dest
+    while read -r bin dest; do
+        [ -n "$bin" ] || continue
+        [ -f "$srcdir/$bin" ] || continue
+        if [ -e "$dest" ] && ! is_elf "$dest"; then
+            echo "  $tool: $dest is not a binary; refusing to overwrite"
+            return 1
+        fi
+        mkdir -p "$(dirname "$dest")"
+        cp "$srcdir/$bin" "$dest"
+        chmod +x "$dest"
+        cmp -s "$srcdir/$bin" "$dest" || { echo "  $tool: $dest did not land"; return 1; }
+        echo "  $tool($arch): $bin -> $dest"
+    done <<< "$(dests "$tool" "$arch")"
+}
 
 N=$($YQ -r '.outdated | length' "$OUTDATED")
 echo "bumping $N tools"
@@ -35,32 +65,14 @@ while [ $i -lt $N ]; do
 
     # verify every declared output actually built before touching the repo
     MISSING=0
-    for BIN in $($YQ -r ".tools[] | select(.name == \"$TOOL\") | .outputs | map(.bin // .) | join(\" \")" tools.yaml); do
+    for BIN in $(dests "$TOOL" x64 | cut -d" " -f1); do
         [ -f "$XDIR/$BIN" ] || { echo "  $TOOL: missing output $BIN; skipping"; MISSING=1; }
     done
     [ $MISSING = 0 ] || continue
 
-    # x64 binaries
-    for SRCBIN in "$XDIR"/*; do
-        BIN=$(basename "$SRCBIN")
-        DEST=$(git ls-files "x64/**/$BIN" "x64/$BIN" | head -1)
-        DEST=${DEST:-"x64/$BIN"}
-        mkdir -p "$(dirname "$DEST")"
-        cp "$SRCBIN" "$DEST"
-        chmod +x "$DEST"
-        echo "  $TOOL: $SRCBIN -> $DEST"
-    done
-    # arm binaries (dir may be empty or absent)
+    install_arch "$TOOL" x64 "$XDIR" || continue
     if [ -d "$ADIR" ] && compgen -G "$ADIR/*" > /dev/null; then
-        for SRCBIN in "$ADIR"/*; do
-            BIN=$(basename "$SRCBIN")
-            DEST=$(git ls-files "arm/**/$BIN" "arm/$BIN" | head -1)
-            DEST=${DEST:-"arm/$BIN"}
-            mkdir -p "$(dirname "$DEST")"
-            cp "$SRCBIN" "$DEST"
-            chmod +x "$DEST"
-            echo "  $TOOL(arm): $SRCBIN -> $DEST"
-        done
+        install_arch "$TOOL" arm "$ADIR" || continue
     fi
 
     CURRENT=$($YQ -r ".tools[] | select(.name == \"$TOOL\") | .version" tools.yaml)
@@ -71,7 +83,8 @@ while [ $i -lt $N ]; do
 done
 
 if [ -n "$BUMPED" ]; then
-    python3 scripts/update_readme.py "$DIST" $BUMPED
+    # shellcheck disable=SC2086 -- BUMPED is a space-separated NAME=VER list
+    python3 scripts/update_readme.py $BUMPED
 fi
 
 echo "$BUMPED_JSON" > "$BUMPED_OUT"

--- a/scripts/check_upstream.py
+++ b/scripts/check_upstream.py
@@ -40,9 +40,20 @@ def http_get(url):
         return r.read().decode("utf-8", "replace")
 
 
+# A delimited trailing word is a prerelease and sorts below the plain release
+# (1.0.0-alpha < 1.0.0); a letter glued to a digit is a patch level and sorts
+# above it (tmux 3.7 < 3.7c).
+PRERELEASE = re.compile(r"[._\-+~](alpha|beta|rc|pre|dev|snapshot)[\w.]*$", re.I)
+
+
 def version_key(v):
     """Sort key tolerant of mixed versions: 1.7 < 1.10, 4.5.0, 20240606."""
-    parts = re.split(r"[._\-+~]", v.lstrip("v"))
+    v = v.lstrip("v")
+    pre = ""
+    m = PRERELEASE.search(v)
+    if m:
+        pre, v = m.group(0)[1:].lower(), v[:m.start()]
+    parts = re.split(r"[._\-+~]", v)
     key = []
     for p in parts:
         if p.isdigit():
@@ -56,7 +67,20 @@ def version_key(v):
                 key.append((1, m.group(2)))
             else:
                 key.append((1, p))
+    # trailing marker: every version carries one, so a prerelease loses the
+    # comparison against its own release instead of merely being longer
+    key.append((0, pre) if pre else (1, ""))
     return key
+
+
+def is_newer(latest, cur):
+    """True only when `latest` sorts strictly above `cur`.
+
+    An upstream that is behind (rs/dnstrace tags 1.4.0 while we ship 1.4.3) or
+    on an incomparable scheme (a release tag vs a pinned commit sha) must not
+    trigger a bump -- that ships an older binary under a newer version string.
+    """
+    return version_key(latest) > version_key(cur)
 
 
 def pick_max(candidates):
@@ -193,7 +217,13 @@ def check_one(t):
     if not latest:
         return name, t.get("version"), "error: no version found upstream"
     cur = t.get("version", "")
-    status = "outdated" if version_key(latest) != version_key(cur) else "ok"
+    if version_key(latest) == version_key(cur):
+        status = "ok"
+    elif is_newer(latest, cur):
+        status = "outdated"
+    else:
+        # upstream is behind us or uses a different scheme: report, never bump
+        status = f"ahead: shipped {cur} > upstream {latest}"
     return name, latest, status
 
 
@@ -218,11 +248,11 @@ def main():
             name, latest, status = fut.result()
             results[name] = {"latest": latest, "status": status}
             mark = {"outdated": "!!", "ok": "  ", "pinned": "--",
-                    "disabled": "--"}.get(status.split(":")[0], "??")
+                    "disabled": "--", "ahead": "<<"}.get(status.split(":")[0], "??")
             line = f"{mark} {name:<22} shipped={str(tools_next(name, tools)):<14}"
             if latest:
                 line += f"latest={latest}"
-            if args.all or status.startswith(("outdated", "error")):
+            if args.all or status.startswith(("outdated", "error", "ahead")):
                 print(line + ("" if status == "outdated" else f"   [{status}]"),
                       file=sys.stderr)
 

--- a/scripts/manifest.py
+++ b/scripts/manifest.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import shutil
+import sys
 
 
 def _yq():
@@ -32,18 +33,50 @@ def tool_by_name(name, tools=None):
     raise KeyError(name)
 
 
+ARCHES = ("x64", "arm")
+
+
+def _entries(t, arch):
+    """Raw `outputs` / `arm_outputs` list. `same` mirrors the x64 outputs."""
+    outs = t.get("arm_outputs") if arch == "arm" else t.get("outputs")
+    if outs in ("same", ["same"]):
+        outs = t.get("outputs")
+    return outs or []
+
+
+def outputs(t, arch="x64"):
+    """[(bin, dest)] for one arch, dest relative to the repo root.
+
+    The destination is read from the manifest and never searched for in the
+    tree: `git ls-files "x64/tor"` matches every file under x64/tor/, README
+    included, which is how a tor binary once landed on top of its own docs.
+    """
+    entries = _entries(t, arch)
+    bins = [(e["bin"] if isinstance(e, dict) else e) for e in entries]
+    flat = len(bins) == 1 and bins[0] == t["name"]
+
+    resolved = []
+    for entry, b in zip(entries, bins):
+        dst = entry.get("dst") if isinstance(entry, dict) else None
+        resolved.append((b, f"{arch}/{dst or (b if flat else t['name'] + '/' + b)}"))
+    return resolved
+
+
 def output_bins(t):
-    outs = t.get("outputs") or []
-    return [(o["bin"] if isinstance(o, dict) else o) for o in outs]
+    return [b for b, _ in outputs(t, "x64")]
 
 
 def arm_bins(t):
-    outs = t.get("arm_outputs") or []
-    if outs == ["same"]:
-        return output_bins(t)
-    return [(o["bin"] if isinstance(o, dict) else o) for o in outs]
+    return [b for b, _ in outputs(t, "arm")]
 
 
-def first_bin(t):
-    bins = output_bins(t)
-    return bins[0] if bins else None
+def _cli():
+    """`manifest.py dests <tool> <arch>` -> one "<bin> <path>" line per output."""
+    if len(sys.argv) != 4 or sys.argv[1] != "dests":
+        raise SystemExit("usage: manifest.py dests <tool> <arch>")
+    for b, dest in outputs(tool_by_name(sys.argv[2]), sys.argv[3]):
+        print(f"{b} {dest}")
+
+
+if __name__ == "__main__":
+    _cli()

--- a/scripts/test_layout.py
+++ b/scripts/test_layout.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Regression tests for manifest path resolution and version ordering.
+
+usage: python3 scripts/test_layout.py    (also a lint-buildfiles CI step)
+
+Guards the two defects that shipped in the 2026-08-31 bump PR:
+  1. apply_bump.sh guessed a binary's destination with
+     `git ls-files "x64/**/$BIN" "x64/$BIN"`. The second pathspec matches a
+     whole directory, so for BIN=tor git returned x64/tor/README.md first and
+     the tor binary was written over the docs. Destinations now come from
+     tools.yaml only.
+  2. check_upstream treated any version difference as "outdated", so an
+     upstream release older than the shipped one (dnstrace 1.4.3 -> 1.4.0)
+     was published as a bump.
+"""
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from check_upstream import is_newer, pick_max  # noqa: E402
+from manifest import ARCHES, load_tools, outputs  # noqa: E402
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DOC_EXT = (".md", ".txt", ".conf", ".json", ".yaml", ".yml")
+
+failures = []
+
+
+def check(cond, msg):
+    if not cond:
+        failures.append(msg)
+
+
+def tracked():
+    out = subprocess.run(["git", "ls-files"], cwd=ROOT, capture_output=True,
+                         text=True, check=True).stdout.split()
+    files = set(out)
+    dirs = {d for f in files for d in _parents(f)}
+    return files, dirs
+
+
+def _parents(path):
+    parts = path.split("/")[:-1]
+    return ["/".join(parts[:i + 1]) for i in range(len(parts))]
+
+
+def test_destinations(files, dirs):
+    """Every declared output maps to a binary path, never a doc or a directory."""
+    for t in load_tools():
+        for arch in ARCHES:
+            for binname, dest in outputs(t, arch):
+                where = f"{t['name']}/{arch}/{binname}"
+                check(not dest.endswith(DOC_EXT),
+                      f"{where}: destination {dest} is a doc file")
+                check(dest not in dirs,
+                      f"{where}: destination {dest} is a directory; set an "
+                      f"explicit dst in tools.yaml")
+                if dest in files:
+                    check(_is_elf(dest), f"{where}: {dest} is tracked but not ELF")
+
+
+def test_no_relocation(files):
+    """A bump must overwrite the shipped binary, not create a second copy."""
+    for t in load_tools():
+        for arch in ARCHES:
+            declared = {d for _, d in outputs(t, arch)}
+            for binname, dest in outputs(t, arch):
+                shipped = [f for f in files
+                           if f.startswith(f"{arch}/") and os.path.basename(f) == binname]
+                if not shipped or dest in files:
+                    continue
+                check(set(shipped) & declared,
+                      f"{t['name']}/{arch}/{binname}: manifest says {dest} but "
+                      f"the repo ships {shipped}")
+
+
+def test_clobbered_docs(files):
+    """The exact files the bad PR overwrote."""
+    for doc in ("x64/tor/README.md", "x64/zmap/README.md"):
+        check(doc in files, f"{doc} missing from the repo")
+        check(not _is_elf(doc), f"{doc} is a binary, not documentation")
+
+
+def test_arm_same_expands():
+    """`arm_outputs: same` is a scalar in tools.yaml; splitting it yields s,a,m,e."""
+    for t in load_tools():
+        if t.get("arm_outputs") != "same":
+            continue
+        arm = [b for b, _ in outputs(t, "arm")]
+        check(arm == [b for b, _ in outputs(t, "x64")],
+              f"{t['name']}: arm_outputs 'same' expanded to {arm}")
+        return
+    check(False, "no tool uses `arm_outputs: same`; test is stale")
+
+
+def test_version_ordering():
+    check(is_newer("1.4.3", "1.4.0"), "1.4.3 should be newer than 1.4.0")
+    check(not is_newer("1.4.0", "1.4.3"), "dnstrace downgrade 1.4.3 -> 1.4.0")
+    check(not is_newer("1.8.2", "1.8.2"), "equal versions are not newer")
+    check(is_newer("1.10", "1.7"), "1.10 should be newer than 1.7")
+    check(is_newer("v2.13.0", "2.8.1"), "leading v must not break ordering")
+    check(not is_newer("0.4.10", "e5b49ef"),
+          "a tagged release is not comparable to a shipped commit sha")
+    # a delimited suffix is a prerelease (older); one glued to a digit is a
+    # patch letter (newer): 1.0.0 > 1.0.0-alpha, but tmux 3.7c > 3.7
+    check(is_newer("1.0.0", "1.0.0-alpha"), "1.0.0 is newer than 1.0.0-alpha")
+    check(not is_newer("1.0.0-alpha", "1.0.0"), "1.0.0-alpha is not a bump")
+    check(is_newer("3.7c", "3.7"), "3.7c is newer than 3.7")
+    check(is_newer("1.8.2", "1.8.2-rc1"), "release beats its own rc")
+    check(pick_max(["1.0.0", "1.0.0-rc1", "0.9.9"]) == "1.0.0",
+          "pick_max must not choose a prerelease over its release")
+
+
+def _is_elf(path):
+    with open(os.path.join(ROOT, path), "rb") as f:
+        return f.read(4) == b"\x7fELF"
+
+
+def main():
+    files, dirs = tracked()
+    test_destinations(files, dirs)
+    test_no_relocation(files)
+    test_clobbered_docs(files)
+    test_arm_same_expands()
+    test_version_ordering()
+
+    for f in failures:
+        print(f"FAIL {f}", file=sys.stderr)
+    print(f"{'FAILED' if failures else 'OK'}: {len(failures)} failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Update README.md version/SHA256 columns for bumped tools.
 
-usage: update_readme.py <dist-root> NAME=NEWVER [NAME=NEWVER ...]
+usage: update_readme.py NAME=NEWVER [NAME=NEWVER ...]
 
-Reads artifact hashes from <dist-root>/bt-<name>/x64/<first-output> and rewrites
-the matching table row(s). Version column is padded to its original width so
-the tables stay aligned.
+Hashes the binary as it landed in the repo (outputs[0].dst) and rewrites the
+matching table row(s), so the published SHA256 always describes the file a user
+downloads. Version column is padded to its original width so tables stay aligned.
 """
 import hashlib
 import os
@@ -13,7 +13,7 @@ import re
 import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
-from manifest import load_tools, first_bin  # noqa: E402
+from manifest import load_tools, outputs  # noqa: E402
 
 ROW = re.compile(
     r"^(?P<pre>\|\s*\[[^\]]+\]\([^)]*\)\s*\|)\s*(?P<ver>[^|]+?)\s*\|"
@@ -29,22 +29,19 @@ FILENAME_CELL = {
 }
 
 
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
 def cell_for(name):
     return FILENAME_CELL.get(name, name)
 
 
-def sha_of(dist_root, name):
-    d = os.path.join(dist_root, f"bt-{name}", "x64")
-    binname = None
-    for t in load_tools():
-        if t["name"] == name:
-            outs = t.get("outputs") or []
-            bins = [(o["bin"] if isinstance(o, dict) else o) for o in outs]
-            binname = first_bin(t)
-            break
-    if not binname:
+def sha_of(root, name):
+    """SHA256 of the shipped binary, read from the repo rather than from dist/."""
+    outs = next((outputs(t) for t in load_tools() if t["name"] == name), [])
+    if not outs:
         return None
-    p = os.path.join(d, binname)
+    p = os.path.join(root, outs[0][1])
     if not os.path.exists(p):
         return None
     h = hashlib.sha256()
@@ -55,14 +52,12 @@ def sha_of(dist_root, name):
 
 
 def main():
-    dist_root = sys.argv[1]
     bumps = {}
-    for arg in sys.argv[2:]:
+    for arg in sys.argv[1:]:
         name, _, ver = arg.partition("=")
         bumps[name] = ver
 
-    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                        "README.md")
+    path = os.path.join(ROOT, "README.md")
     lines = open(path).read().split("\n")
 
     # which table section each line belongs to
@@ -80,21 +75,12 @@ def main():
         for name, ver in bumps.items():
             if f"`{cell_for(name)}`" != fn and cell_for(name) not in fn.strip("`"):
                 continue
-            sha = sha_of(dist_root, name)
-            new_ver = f" {ver} "
-            old = m.group("ver")
-            pad = len(old) - len(new_ver)
-            if pad > 0:
-                new_ver = f" {ver} ".ljust(len(old))
-            elif pad < 0:
-                pass  # let the row grow; markdown tolerates it
-            nl = (f"{m.group('pre')}{new_ver}|"
-                  f"{line.split('|')[3].join(['|',''])}"  # placeholder, rebuilt below
-                  )
-            # rebuild row explicitly to avoid column juggling bugs
+            sha = sha_of(ROOT, name)
             parts = line.split("|")
             # parts: '', sw, ver, fn, cat, sha, ''
-            parts[2] = new_ver.rstrip() if False else f" {new_ver.strip()} "
+            # keep the original cell width when the new version fits; a longer
+            # one just grows the row (markdown tolerates ragged tables)
+            parts[2] = f" {ver} ".ljust(len(parts[2]))
             if sha:
                 parts[5] = f" `{sha}` "
             lines[i] = "|".join(parts)

--- a/tools.yaml
+++ b/tools.yaml
@@ -23,8 +23,11 @@
 #   project    sourceforge project id
 #   lang       build language hint: go | rust | c | cxx | mixed
 #   outputs    binaries produced by build/<name>/Dockerfile into /out/x64/
-#              [{bin, dst}]; dst defaults to x64/<name>/<bin>, or x64/<bin>
-#              when there is a single output whose bin == name
+#              [{bin, dst}]; dst is the repo path under x64/ (arm/ for
+#              arm_outputs) and defaults to <name>/<bin>, or <bin> when there
+#              is a single output whose bin == name. Set it explicitly whenever
+#              the shipped layout differs -- scripts/test_layout.py enforces
+#              that every dst names a real binary, never a directory or a doc.
 #   arm_outputs  same shape, copied from /out/arm/ (ARMv7 hard-float musl)
 #   test       args appended to each output binary for the smoke test;
 #              false disables; test_cmd overrides the whole command
@@ -93,7 +96,9 @@ tools:
     lang: rust
     outputs:
       - bin: boringtun
+        dst: boringtun
       - bin: wg-user
+        dst: wg-user
         note: legacy boringtun-cli alias kept for backwards compatibility
     test: "--version"
   - name: brook
@@ -156,8 +161,8 @@ tools:
     version: "1.20241021"
     check: {type: git-remote, remote: 'https://www.bamsoftware.com/git/dnstt.git', pattern: '^v(.+)$'}
     lang: go
-    outputs: [dnstt_client, dnstt_server]
-    arm_outputs: [dnstt_client, dnstt_server]
+    outputs: [{bin: dnstt_client, dst: dnstt_client}, {bin: dnstt_server, dst: dnstt_server}]
+    arm_outputs: [{bin: dnstt_client, dst: dnstt_client}, {bin: dnstt_server, dst: dnstt_server}]
     test: "-h"
   - name: doggo
     version: "1.0.4"
@@ -222,8 +227,8 @@ tools:
     version: "0.48.0"
     check: {type: github-release, slug: fatedier/frp}
     lang: go
-    outputs: [frpc, frps]
-    arm_outputs: [frpc, frps]
+    outputs: [{bin: frpc, dst: frpc}, {bin: frps, dst: frps}]
+    arm_outputs: [{bin: frpc, dst: frpc}, {bin: frps, dst: frps}]
     test: "--version"
   - name: fzf
     version: "0.36.0"
@@ -311,7 +316,7 @@ tools:
       url: https://ftp.gnu.org/gnu/httptunnel/
       pattern: 'httptunnel-(\d+\.\d+)\.tar\.gz'
     lang: c
-    outputs: [httptunnel-client, httptunnel-server]
+    outputs: [{bin: httptunnel-client, dst: httptunnel-client}, {bin: httptunnel-server, dst: httptunnel-server}]
     test: "--help"
   - name: httpx
     version: "1.2.9"
@@ -342,7 +347,7 @@ tools:
     version: "0.8.0"
     check: {type: github-tag, slug: yarrick/iodine}
     lang: c
-    outputs: [iodine, iodined]
+    outputs: [{bin: iodine, dst: iodine}, {bin: iodined, dst: iodined}]
     test_cmd: "/out/x64/iodine 2>&1 | grep -q iodine"
   - name: ioping
     version: "0.9"
@@ -487,7 +492,7 @@ tools:
       url: https://nmap.org/dist/
       pattern: 'nmap-(\d+\.\d+(?:\.\d+)?)\.tar\.bz2'
     lang: c
-    outputs: [nmap, nping]
+    outputs: [{bin: nmap, dst: nmap}, {bin: nping, dst: nping}]
     test: "--version"
     experimental: true
   - name: nomino
@@ -703,14 +708,16 @@ tools:
       remote: https://gitlab.torproject.org/tpo/core/tor.git
       pattern: '^tor-(\d+\.\d+\.\d+(?:\.\d+)?)$'
     lang: c
-    outputs: [tor]
+    outputs: [{bin: tor, dst: tor/tor}]
     test_cmd: "/out/x64/tor --version 2>&1 | grep -qi tor"
     experimental: true
   - name: pt_bridges
     version: "0.4.8.0-compat"
     check: {type: pinned, reason: webtunnel has no tags; bridges tracked manually}
     lang: go
-    outputs: [lyrebird, snowflake, webtunnel_client, webtunnel_server]
+    outputs: [{bin: lyrebird, dst: tor/lyrebird}, {bin: snowflake, dst: tor/snowflake},
+              {bin: webtunnel_client, dst: tor/webtunnel_client},
+              {bin: webtunnel_server, dst: tor/webtunnel_server}]
     test: "--version"
     experimental: true
   - name: tmux


### PR DESCRIPTION
Fixes the two defects that made #11 unmergeable.

**Destinations were guessed from the tree.** `apply_bump.sh` resolved a binary's
path with `git ls-files "x64/**/$BIN" "x64/$BIN"`. The second pathspec matches a
whole directory, so for `BIN=tor` git listed `x64/tor/README.md` first and
`head -1` picked it: #11 committed the tor and zmap binaries over their own
documentation, left `x64/tor/tor` and `x64/zmap/zmap` at the old build, and
bumped the versions and hashes anyway.

Destinations now come from `tools.yaml` only (`manifest.outputs()`). Every tool
whose layout differs from the default carries an explicit `dst`; copies refuse
to overwrite a non-ELF file and verify the bytes landed.

**Any version difference counted as a bump.** #11 downgraded dnstrace
1.4.3 -> 1.4.0. `check_upstream` now bumps only when upstream sorts strictly
higher and reports the rest as `ahead`. `version_key` also learned that a
delimited suffix is a prerelease (`1.0.0-alpha` < `1.0.0`) while a letter glued
to a digit is a patch level (`3.7` < `3.7c`) — that alone unblocks icmptunnel.

README hashes now come from the binary as it landed in the repo rather than from
the build artifact, so a published SHA256 always describes the file a user
downloads. The version column keeps its padding.

`scripts/test_layout.py` covers both defects and runs in lint-buildfiles. A bot
PR does not trigger that workflow (its checks sit in `action_required`), so the
bump job now runs the tests itself and fails if it wrote over any documentation.

Still needs a human decision, unchanged by this PR:
- **goss** — `tools.yaml` and the Dockerfile track `goss-org/goss`, the README
  links `cakturk/go-netstat`, and the shipped `e5b49ef` binary came from the
  latter. Two different tools under one filename. Now reported as `ahead`
  instead of silently swapped.
- **dnstrace, logtop** — also `ahead`; upstream has no tag above what ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)