### PR TITLE
Fix ARM smoke tests and three broken builds

### DIFF
--- a/build/dsvpn/Dockerfile
+++ b/build/dsvpn/Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex \
  && mkdir -p /tmp/out-arm \
  && make clean || true \
  && sed -i '/^\tstrip /d' Makefile \
- && make CC=arm-linux-musleabihf-gcc CFLAGS='-O2' LDFLAGS=-static -j$(nproc) \
+ && make CC=arm-linux-musleabihf-gcc CFLAGS='-O2 -static' LDFLAGS=-static -j$(nproc) \
  && cp dsvpn /tmp/out-arm/
 
 RUN set -ex \

--- a/build/icmptunnel/Dockerfile
+++ b/build/icmptunnel/Dockerfile
@@ -19,7 +19,7 @@ ENV PATH=/opt/arm-linux-musleabihf-cross/bin:$PATH
 RUN set -ex \
  && mkdir -p /tmp/out-arm \
  && make clean || true \
- && make -j$(nproc) CC=arm-linux-musleabihf-gcc LDFLAGS=-static \
+ && make -j$(nproc) CC=arm-linux-musleabihf-gcc CFLAGS='-O2 -static' LDFLAGS=-static \
  && cp icmptunnel /tmp/out-arm/
 
 RUN set -ex \

--- a/build/lnav/Dockerfile
+++ b/build/lnav/Dockerfile
@@ -4,12 +4,13 @@
 
 FROM alpine:3.20 AS build
 ARG VERSION
-RUN apk add --no-cache build-base git ca-certificates curl upx linux-headers xz bzip2 cmake autoconf automake libtool ncurses-static sqlite-static sqlite-dev zlib-static curl-dev openssl-libs-static
+RUN apk add --no-cache build-base git ca-certificates curl upx linux-headers xz bzip2 cmake autoconf automake libtool ncurses-static sqlite-static sqlite-dev zlib-static curl-dev openssl-libs-static libunistring-dev libunistring-static curl-static nghttp2-static brotli-static zstd-static libidn2-static c-ares-static libpsl-static pkgconf
 RUN git clone --depth 1 https://github.com/tstack/lnav.git /src && cd /src && REF="v${VERSION}" && (git fetch --depth 1 origin tag $REF 2>/dev/null; git checkout $REF 2>/dev/null) || (git fetch --depth 1 origin tag $REF.0 2>/dev/null; git checkout $REF.0 2>/dev/null) || (git fetch --depth 1 origin tag v${VERSION} 2>/dev/null; git checkout v${VERSION} 2>/dev/null) || (git fetch --depth 1 origin tag v${VERSION}.0 2>/dev/null; git checkout v${VERSION}.0 2>/dev/null) || (git fetch --depth 1 origin tag ${VERSION} 2>/dev/null; git checkout ${VERSION} 2>/dev/null) || (git fetch --unshallow 2>/dev/null || git fetch --depth 1000 origin 2>/dev/null; git checkout ${VERSION} 2>/dev/null) || true; cd /
 WORKDIR /src
+RUN mkdir -p /pcre2-src /opt/pcre2 && curl -fsSL --retry 3 https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz | gunzip -c | tar x -C /pcre2-src --strip-components=1 && cd /pcre2-src && ./configure --prefix=/opt/pcre2 --disable-shared --enable-static && make -j$(nproc) && make install && cd /src
 RUN set -ex \
  && mkdir -p /tmp/out \
- && ./autogen.sh && ./configure LDFLAGS=-static \
+ && ./autogen.sh && PKG_CONFIG_PATH=/opt/pcre2/lib/pkgconfig PKG_CONFIG='pkg-config --static' ./configure LDFLAGS='-static -L/opt/pcre2/lib' CPPFLAGS=-I/opt/pcre2/include LIBS="$(pkg-config --static --libs libcurl)" \
  && make -j$(nproc) \
  && cp src/lnav /tmp/out/
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,21 +38,30 @@ run_x64() {
     docker run --rm --entrypoint /bin/sh "$IMAGE" -ec "$1"
 }
 
+QEMU_IN=/qemu-arm  # where qemu-arm-static is mounted inside the image
+
+# A daemon that ignores --version blocks forever: 3proxy burned a 2h job that
+# way. Tools that need more than a flag carry a `test_cmd` with their own guard.
+SMOKE_TIMEOUT="timeout 20"
+
+run_arm() {
+    docker run --rm -v "$QEMU":"$QEMU_IN":ro --entrypoint /bin/sh "$IMAGE" -ec "$1"
+}
+
 if [[ -n "$TEST_CMD" && "$TEST_CMD" != "null" ]]; then
     run_x64 "$TEST_CMD"
 else
     BINS=$($YQ -r "$sel | .outputs | map(.bin // .) | join(\" \")" tools.yaml)
     for b in $BINS; do
         echo "    /out/x64/$b $TEST_ARGS"
-        if docker run --rm --entrypoint /bin/sh "$IMAGE" -ec "/out/x64/$b $TEST_ARGS >/dev/null" 2>/dev/null; then
+        if run_x64 "$SMOKE_TIMEOUT /out/x64/$b $TEST_ARGS >/dev/null 2>&1"; then
             continue
         fi
         # not every tool supports the manifest's default flag; walk a ladder
         # of common version/help invocations before giving up
         OK=0
         for args in "--version" "-V" "-v" "version" "--help" "-h"; do
-            if docker run --rm --entrypoint /bin/sh "$IMAGE" \
-                -ec "/out/x64/$b $args >/dev/null 2>&1"; then OK=1; break; fi
+            if run_x64 "$SMOKE_TIMEOUT /out/x64/$b $args >/dev/null 2>&1"; then OK=1; break; fi
         done
         [ $OK = 1 ] || { echo "smoke test failed for /out/x64/$b"; exit 1; }
     done
@@ -60,7 +69,12 @@ fi
 
 # ARM smoke test through qemu-user-static if the host provides it.
 # ARM is only shipped when the tool declares arm outputs; if we ship it, it
-# must pass the same ladder as x64 -- a broken ARM binary never lands in a PR.
+# must pass the same checks as x64 -- a broken ARM binary never lands in a PR.
+# qemu is static, so it is bind-mounted into the image and the ARM binaries run
+# against the same filesystem the x64 run used: a `test_cmd` that prepares a
+# helper first (termshark stubs tshark) still works, and nothing touches the
+# host. test_cmd matters here: dsvpn and icmptunnel exit non-zero on every flag
+# in the ladder below, so without it they can never pass ARM.
 if docker run --rm --entrypoint /bin/sh "$IMAGE" -ec 'ls /out/arm/* >/dev/null 2>&1' 2>/dev/null; then
     ARM_SHIPPED=1
 else
@@ -71,21 +85,20 @@ if [[ $ARM_SHIPPED == 1 ]]; then
     if [[ -z "$QEMU" && -x /usr/bin/qemu-arm-static ]]; then QEMU=/usr/bin/qemu-arm-static; fi
     if [[ -n "$QEMU" ]]; then
         echo "==> smoke test (arm via qemu)"
-        ARMDIR=$(mktemp -d)
-        CID=$(docker create "$IMAGE")
-        docker cp -q "$CID":/out/arm/. "$ARMDIR" >/dev/null 2>&1 || docker cp "$CID":/out/arm/. "$ARMDIR"
-        docker rm "$CID" >/dev/null
-        for b in "$ARMDIR"/*; do
-            echo "    arm $(basename "$b")"
-            "$QEMU" "$b" $TEST_ARGS >/dev/null 2>&1 && continue
-            # same fallback ladder as x64; if none pass, the ARM binary is broken
-            OK=0
-            for args in "--version" "-V" "-v" "version" "--help" "-h"; do
-                if "$QEMU" "$b" $args >/dev/null 2>&1; then OK=1; break; fi
+        if [[ -n "$TEST_CMD" && "$TEST_CMD" != "null" ]]; then
+            run_arm "${TEST_CMD//\/out\/x64\//$QEMU_IN /out/arm/}"
+        else
+            for b in $(run_x64 'ls /out/arm'); do
+                echo "    arm $b"
+                run_arm "$SMOKE_TIMEOUT $QEMU_IN /out/arm/$b $TEST_ARGS >/dev/null 2>&1" && continue
+                # same fallback ladder as x64; if none pass, the binary is broken
+                OK=0
+                for args in "--version" "-V" "-v" "version" "--help" "-h"; do
+                    if run_arm "$SMOKE_TIMEOUT $QEMU_IN /out/arm/$b $args >/dev/null 2>&1"; then OK=1; break; fi
+                done
+                [ $OK = 1 ] || { echo "arm smoke test failed for /out/arm/$b"; exit 1; }
             done
-            [ $OK = 1 ] || { echo "arm smoke test failed for /out/arm/$(basename "$b")"; exit 1; }
-        done
-        rm -rf "$ARMDIR"
+        fi
     else
         echo "==> arm binaries present (qemu unavailable locally; CI installs it)"
     fi

--- a/scripts/recipes_c.py
+++ b/scripts/recipes_c.py
@@ -26,7 +26,8 @@ RECIPES = {
         build=["make CC=gcc LDFLAGS=-static -j$(nproc)", "cp dsvpn /tmp/out/"],
         arm_build=["make clean || true",
                    "sed -i '/^\\tstrip /d' Makefile",
-                   "make CC=arm-linux-musleabihf-gcc CFLAGS='-O2' LDFLAGS=-static -j$(nproc)",
+                   # the Makefile links with CFLAGS, so -static must be there too
+                   "make CC=arm-linux-musleabihf-gcc CFLAGS='-O2 -static' LDFLAGS=-static -j$(nproc)",
                    "cp dsvpn /tmp/out-arm/"],
     ),
     "corkscrew": dict(
@@ -59,7 +60,8 @@ RECIPES = {
         bins=[("icmptunnel", "")],
         build=["make -j$(nproc) LDFLAGS=-static", "cp icmptunnel /tmp/out/"],
         arm_build=["make clean || true",
-                   "make -j$(nproc) CC=arm-linux-musleabihf-gcc LDFLAGS=-static",
+                   # LDFLAGS alone leaves a musl-dynamic binary: link via CFLAGS too
+                   "make -j$(nproc) CC=arm-linux-musleabihf-gcc CFLAGS='-O2 -static' LDFLAGS=-static",
                    "cp icmptunnel /tmp/out-arm/"],
     ),
     "wg": dict(
@@ -288,8 +290,21 @@ RECIPES = {
         lang="cxx", slug="tstack/lnav", tag_prefix="v",
         bins=[("lnav", "")],
         pkgs=["cmake", "autoconf", "automake", "libtool", "ncurses-static",
-              "sqlite-static", "sqlite-dev", "zlib-static", "curl-dev", "openssl-libs-static"],
-        build=["./autogen.sh && ./configure LDFLAGS=-static",
+              "sqlite-static", "sqlite-dev", "zlib-static", "curl-dev", "openssl-libs-static",
+              # configure links its probes statically, so every curl
+              # dependency needs its .a here too
+              "libunistring-dev", "libunistring-static", "curl-static",
+              "nghttp2-static", "brotli-static", "zstd-static",
+              "libidn2-static", "c-ares-static", "libpsl-static", "pkgconf"],
+        # alpine ships no static libpcre2 -- build one, same as suricata
+        pre=["mkdir -p /pcre2-src /opt/pcre2",
+             "curl -fsSL --retry 3 https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz | "
+             "gunzip -c | tar x -C /pcre2-src --strip-components=1",
+             "cd /pcre2-src && ./configure --prefix=/opt/pcre2 --disable-shared --enable-static "
+             "&& make -j$(nproc) && make install && cd /src"],
+        build=["./autogen.sh && PKG_CONFIG_PATH=/opt/pcre2/lib/pkgconfig PKG_CONFIG='pkg-config --static' ./configure "
+               "LDFLAGS='-static -L/opt/pcre2/lib' CPPFLAGS=-I/opt/pcre2/include "
+               "LIBS=\"$(pkg-config --static --libs libcurl)\"",
                "make -j$(nproc)", "cp src/lnav /tmp/out/"],
         experimental=True,
     ),

--- a/scripts/test_layout.py
+++ b/scripts/test_layout.py
@@ -14,6 +14,7 @@ Guards the two defects that shipped in the 2026-08-31 bump PR:
      was published as a bump.
 """
 import os
+import re
 import subprocess
 import sys
 
@@ -82,6 +83,24 @@ def test_clobbered_docs(files):
         check(not _is_elf(doc), f"{doc} is a binary, not documentation")
 
 
+def test_smoke_cmd_targets_own_binary():
+    """A test_cmd must exercise the tool it belongs to.
+
+    superfile carried a copy of suricata's command. Nothing failed: the shell's
+    own "/out/x64/suricata: not found" went through `2>&1` into
+    `grep -qiE "Suricata|build-info"`, which matched the path in that very
+    message -- so the tool shipped for months with no smoke test at all.
+    """
+    for t in load_tools():
+        cmd = t.get("test_cmd")
+        if not cmd:
+            continue
+        mine = {b for b, _ in outputs(t, "x64")} | {b for b, _ in outputs(t, "arm")}
+        for ref in re.findall(r"/out/x64/([\w.-]+)", cmd):
+            check(ref in mine,
+                  f"{t['name']}: test_cmd runs /out/x64/{ref}, not one of {sorted(mine)}")
+
+
 def test_arm_same_expands():
     """`arm_outputs: same` is a scalar in tools.yaml; splitting it yields s,a,m,e."""
     for t in load_tools():
@@ -122,6 +141,7 @@ def main():
     test_destinations(files, dirs)
     test_no_relocation(files)
     test_clobbered_docs(files)
+    test_smoke_cmd_targets_own_binary()
     test_arm_same_expands()
     test_version_ordering()
 

--- a/tools.yaml
+++ b/tools.yaml
@@ -663,7 +663,6 @@ tools:
     lang: go
     outputs: [superfile]
     arm_outputs: [superfile]
-    test_cmd: '/out/x64/suricata -V 2>&1 | grep -qiE "Suricata|build-info"'
   - name: tcpdump
     version: "4.99.0"
     check:


### PR DESCRIPTION
Every weekly bump lost the same four tools. All four are fixed and verified locally.

## The ARM smoke test ignored `test_cmd`

`scripts/build.sh` applied `test_cmd` only to x64. ARM fell back to the
`--version / -V / -v / version / --help / -h` ladder, which these tools do not answer:

- **3proxy** starts as a daemon and blocks forever. Its `test_cmd` wraps that in
  `timeout 2` — but only x64 ever saw it, so the job ran until the 120-minute
  limit. That is what burned 2h in the 2026-08-31 run and again today.
- **dsvpn** and **icmptunnel** exit 254 on every flag in the ladder.

ARM binaries now run under a bind-mounted `qemu-arm-static` *inside the image*, so
`test_cmd` applies exactly as on x64 — a command that prepares a helper first
(termshark stubs `tshark`) still works, and nothing leaks onto the runner. Ladder
invocations carry `timeout 20`, so no daemon can hang a job again.

## dsvpn and icmptunnel shipped dynamic ARM binaries

Fixing the test exposed the real defect. Both ARM builds were musl-dynamic despite
`LDFLAGS=-static`, because both Makefiles link through `CFLAGS`. Under qemu:

```
Could not open '/lib/ld-musl-armhf.so.1'
```

The smoke test was right to fail — those binaries would not have run on a real
device either. `-static` now goes through `CFLAGS` as well.

## lnav could not configure

`libunistring` → then `libcurl` → then `pcre2`. Its configure links its probes
statically, so every dependency needs its `.a`, and alpine ships no static
libpcre2 — built from source here, the way suricata already does.

## superfile was never smoke-tested

Its `test_cmd` was a copy of suricata's, pointing at `/out/x64/suricata`. Nothing
failed: the shell's own `/out/x64/suricata: not found` went through `2>&1` into
`grep -qiE "Suricata|build-info"`, which matched the path inside that very error.
superfile answers `--version`, so the default is enough. `scripts/test_layout.py`
now asserts every `test_cmd` names its own tool's binaries.

## Verified

`./scripts/build.sh` locally, x64 and ARM smoke tests both passing:
`3proxy 1.0.0`, `dsvpn 0.1.5`, `icmptunnel 1.0.0`, `lnav 0.14.0`, plus `jq 1.8.2`
as a control for the rewritten ARM path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)