### PR TITLE
Match README rows exactly, hash per architecture

### DIFF
--- a/scripts/test_layout.py
+++ b/scripts/test_layout.py
@@ -21,9 +21,14 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from check_upstream import is_newer, pick_max  # noqa: E402
 from manifest import ARCHES, load_tools, outputs  # noqa: E402
+from update_readme import ROW, cell_for, cell_owners  # noqa: E402
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DOC_EXT = (".md", ".txt", ".conf", ".json", ".yaml", ".yml")
+
+# tools with no row of their own: pt_bridges ships inside the tor/* row, tangd
+# is ARM-only
+NO_README_ROW = {"pt_bridges", "tangd"}
 
 failures = []
 
@@ -101,6 +106,43 @@ def test_smoke_cmd_targets_own_binary():
                   f"{t['name']}: test_cmd runs /out/x64/{ref}, not one of {sorted(mine)}")
 
 
+def test_readme_rows_resolve():
+    """Each tool owns one README row per section, matched on the exact cell.
+
+    Substring matching put strace's version in dnstrace's row, tiny's in
+    tinyproxy's, vi's in vim's, wg's in wg-go's and rg's in rargs'.
+    """
+    owners = cell_owners()
+    names = [t["name"] for t in load_tools()]
+    check(len(owners) == len(names),
+          f"two tools share a README cell: "
+          f"{sorted(set(names) - set(owners.values()))}")
+
+    seen = {}
+    section = None
+    for line in open(os.path.join(ROOT, "README.md")):
+        if line.startswith("# Filename map (x64)"):
+            section = "x64"
+        elif line.startswith("# Filename map (ARM5)"):
+            section = "arm"
+        m = ROW.match(line.rstrip("\n"))
+        if not m or section is None:
+            continue
+        name = owners.get(m.group("fn").strip("`"))
+        if name is None:
+            continue
+        key = (section, name)
+        check(key not in seen, f"{name}: two {section} rows in README.md")
+        seen[key] = True
+
+    for name in names:
+        if name in NO_README_ROW:
+            continue
+        check(("x64", name) in seen,
+              f"{name}: cell '{cell_for(name)}' resolves to no x64 row, so a "
+              f"bump would silently leave its version and hash stale")
+
+
 def test_arm_same_expands():
     """`arm_outputs: same` is a scalar in tools.yaml; splitting it yields s,a,m,e."""
     for t in load_tools():
@@ -142,6 +184,7 @@ def main():
     test_no_relocation(files)
     test_clobbered_docs(files)
     test_smoke_cmd_targets_own_binary()
+    test_readme_rows_resolve()
     test_arm_same_expands()
     test_version_ordering()
 

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -2,10 +2,16 @@
 """Update README.md version/SHA256 columns for bumped tools.
 
 usage: update_readme.py NAME=NEWVER [NAME=NEWVER ...]
+       update_readme.py --sync            (re-derive every row from the repo)
 
-Hashes the binary as it landed in the repo (outputs[0].dst) and rewrites the
-matching table row(s), so the published SHA256 always describes the file a user
-downloads. Version column is padded to its original width so tables stay aligned.
+Rewrites a tool's version and SHA256 cells from tools.yaml and the binary as it
+landed in the repo, per section: the x64 table gets the x64 hash, the ARM table
+the ARM one. Version column keeps its original width so tables stay aligned.
+
+Rows are matched on the exact filename cell. Substring matching used to be
+enough until it wasn't: "strace" is inside "dnstrace", "tiny" inside
+"tinyproxy", "vi" inside "vim", "wg" inside "wg-go", "rg" inside "rargs" -- each
+of those wrote one tool's version and hash into another tool's row.
 """
 import hashlib
 import os
@@ -24,8 +30,10 @@ FILENAME_CELL = {
     "dh": "dh", "hx": "hx", "frp": "frpc/frps", "pueue": "pueue(d)",
     "iodine": "iodine(d)", "nmap": "nmap, nping", "tor": "tor/*",
     "dropbear": "dropbear/*", "netsniff": "netsniff/*", "wireshark": "wireshark/*",
-    "zmap": "zmap/*", "dnspot": "dnspot/*", "sshx": "sshx", "httptunnel_client":
-    "httptunnel-*", "jj": "jj", "q": "`q`", "nc": "nc",
+    "zmap": "zmap/*", "dnspot": "dnspot/*", "sshx": "sshx/server",
+    "httptunnel_client": "httptunnel-*", "jj": "jj", "q": "q", "nc": "nc",
+    "dnstt_client": "dnstt_*",
+    "termsvg": "termvg",  # README typo; fix the cell and this entry together
 }
 
 
@@ -36,9 +44,18 @@ def cell_for(name):
     return FILENAME_CELL.get(name, name)
 
 
-def sha_of(root, name):
-    """SHA256 of the shipped binary, read from the repo rather than from dist/."""
-    outs = next((outputs(t) for t in load_tools() if t["name"] == name), [])
+def cell_owners(tools=None):
+    """filename cell -> tool name. One tool per cell, checked by test_layout."""
+    return {cell_for(t["name"]): t["name"] for t in (tools or load_tools())}
+
+
+def sha_of(root, name, arch):
+    """SHA256 of the shipped binary for one arch, read from the repo.
+
+    The ARM table used to be filled with x64 hashes: every row was hashed from
+    outputs[0] regardless of which section it sat in.
+    """
+    outs = next((outputs(t, arch) for t in load_tools() if t["name"] == name), [])
     if not outs:
         return None
     p = os.path.join(root, outs[0][1])
@@ -52,10 +69,15 @@ def sha_of(root, name):
 
 
 def main():
-    bumps = {}
-    for arg in sys.argv[1:]:
-        name, _, ver = arg.partition("=")
-        bumps[name] = ver
+    tools = load_tools()
+    if sys.argv[1:2] == ["--sync"]:
+        bumps = {t["name"]: t["version"] for t in tools}
+    else:
+        bumps = {}
+        for arg in sys.argv[1:]:
+            name, _, ver = arg.partition("=")
+            bumps[name] = ver
+    owners = cell_owners(tools)
 
     path = os.path.join(ROOT, "README.md")
     lines = open(path).read().split("\n")
@@ -71,25 +93,30 @@ def main():
         m = ROW.match(line)
         if not m or section is None:
             continue
-        fn = m.group("fn")
-        for name, ver in bumps.items():
-            if f"`{cell_for(name)}`" != fn and cell_for(name) not in fn.strip("`"):
-                continue
-            sha = sha_of(ROOT, name)
-            parts = line.split("|")
-            # parts: '', sw, ver, fn, cat, sha, ''
-            # keep the original cell width when the new version fits; a longer
-            # one just grows the row (markdown tolerates ragged tables)
-            parts[2] = f" {ver} ".ljust(len(parts[2]))
-            if sha:
-                parts[5] = f" `{sha}` "
-            lines[i] = "|".join(parts)
-            changed.append((section, name, ver, bool(sha)))
-            break
+        name = owners.get(m.group("fn").strip("`"))
+        if name is None or name not in bumps:
+            continue
+        ver = bumps[name]
+        sha = sha_of(ROOT, name, section)
+        parts = line.split("|")
+        # parts: '', sw, ver, fn, cat, sha, ''
+        # keep the original cell width when the new version fits; a longer
+        # one just grows the row (markdown tolerates ragged tables)
+        parts[2] = f" {ver} ".ljust(len(parts[2]))
+        if sha:
+            parts[5] = f" `{sha}` "
+        lines[i] = "|".join(parts)
+        changed.append((section, name, ver, bool(sha)))
 
     open(path, "w").write("\n".join(lines))
     for sec, name, ver, hashed in changed:
-        print(f"{sec}: {name} -> {ver} sha={'updated' if hashed else 'KEPT (artifact missing)'}")
+        print(f"{sec}: {name} -> {ver} sha={'updated' if hashed else 'KEPT (binary missing)'}")
+
+    # a bump that matched no row is a silent no-op otherwise
+    for name in bumps:
+        if not any(c[1] == name for c in changed):
+            print(f"WARNING: {name} matched no README row (cell "
+                  f"'{cell_for(name)}')", file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two defects in `scripts/update_readme.py`, both visible in the bump PR #14.

## Rows were matched by substring

```python
if f"`{cell_for(name)}`" != fn and cell_for(name) not in fn.strip("`"):
    continue
```

Any tool name contained in another's cell wrote its version and hash into the
wrong row:

| bumped tool | corrupted row | wrong version written |
| --- | --- | --- |
| strace | dnstrace | 7.2 |
| rg | rargs | 15.2.0 |
| tiny | tinyproxy | 0.13.0 |
| vi | vim | 7.9.33 |
| wg | wg-go | 1.0.20260223 |

dnstrace and rargs were not bumped this week — they were held back or untouched —
and their rows were corrupted regardless.

Matching is now exact against a cell → tool index. A bump resolving to no row
prints a warning instead of doing nothing quietly: that silent path is why
`dnstt_client`, `q` and `sshx` have never been updated, their cells (`dnstt_*`,
`q`, `sshx/server`) never matching the tool id. Those mappings are now in
`FILENAME_CELL`.

## Every row was hashed from the x64 binary

`sha_of` always read `outputs[0]`, so each bump wrote x64 hashes into the ARM
table. Verified in #14: `fd`, `fzf`, `jq`, `gojq`, `httpx` — every ARM row there
carries its x64 hash. Hashing is now per section.

## Repair

`update_readme.py --sync` re-derives every row from `tools.yaml` and the shipped
binaries. On master today it corrects **48 rows** — this drift predates the bump
automation. I have not run it here: it has to run after #14 lands, or the hashes
go stale again immediately.

`scripts/test_layout.py` now asserts no two tools claim one cell, no tool owns two
rows in a section, and every tool resolves to a row.

One known-wrong mapping is carried deliberately: the README's termsvg cell reads
`termvg`. Encoding the typo keeps this PR conflict-free with #14; the cell and the
mapping get fixed together in the repair commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)