### PR TITLE
Update the open bump PR instead of failing on it

### DIFF
--- a/.github/workflows/upstream-bump.yml
+++ b/.github/workflows/upstream-bump.yml
@@ -161,12 +161,20 @@ jobs:
           } > body.md
           git commit -m "chore: weekly upstream bumps ($(date +%Y-%m-%d))"
           git push -u --force origin "$BR"
-          gh pr create \
-            --title "chore: weekly upstream bumps ($(date +%Y-%m-%d))" \
-            --body-file body.md \
-            --assignee "$OWNER" \
-            --label automation 2>/dev/null || \
-          gh pr create \
-            --title "chore: weekly upstream bumps ($(date +%Y-%m-%d))" \
-            --body-file body.md \
-            --assignee "$OWNER"
+
+          TITLE="chore: weekly upstream bumps ($(date +%Y-%m-%d))"
+          echo "" >> body.md
+          echo "Built by run ${GITHUB_RUN_ID}." >> body.md
+
+          # A second run on the same day reuses the branch name and force-pushes
+          # over it. Creating a PR then fails and the run ends red with the open
+          # PR silently describing a diff it no longer has -- update it instead.
+          EXISTING=$(gh pr list --head "$BR" --state open --json number -q '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --title "$TITLE" --body-file body.md
+            echo "updated existing PR #$EXISTING"
+            exit 0
+          fi
+          gh pr create --title "$TITLE" --body-file body.md \
+            --assignee "$OWNER" --label automation 2>/dev/null || \
+          gh pr create --title "$TITLE" --body-file body.md --assignee "$OWNER"


### PR DESCRIPTION
The four-tool rerun today reused `bot/upstream-bump-20260902`, force-pushed over the
open weekly PR, then died on `gh pr create` because that PR already existed. The run
went red and #14 was left describing 112 binaries it no longer carried.

The step now edits the existing PR when there is one, and stamps the run id into the
body so binaries can be traced to the build that produced them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)