### PR TITLE
Ship the ARM binaries the builds already produce

### DIFF
--- a/scripts/test_layout.py
+++ b/scripts/test_layout.py
@@ -22,7 +22,8 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from check_upstream import is_newer, pick_max  # noqa: E402
 from manifest import ARCHES, load_tools, outputs  # noqa: E402
-from update_readme import ROW, cell_for, cell_owners  # noqa: E402
+from update_readme import (ROW, arm_row, cell_for, cell_owners,  # noqa: E402
+                           insert_arm_rows)
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DOC_EXT = (".md", ".txt", ".conf", ".json", ".yaml", ".yml")
@@ -181,6 +182,35 @@ def test_readme_matches_binaries():
               f"tools.yaml says {tools[name]['version']}")
 
 
+def test_arm_row_creation():
+    """A tool that starts shipping ARM gets a well-formed row, in order."""
+    lines = open(os.path.join(ROOT, "README.md")).read().split("\n")
+    arm_start = next(i for i, l in enumerate(lines)
+                     if l.startswith("# Filename map (ARM5)"))
+    arm_lines = [l for l in lines[arm_start:] if ROW.match(l)]
+    x64 = next(l for l in lines[:arm_start] if ROW.match(l))
+
+    sha = "0" * 64
+    row = arm_row(x64, arm_lines, "9.9.9", sha)
+    m = ROW.match(row)
+    check(m is not None, f"generated ARM row does not parse: {row}")
+    if m:
+        check(m.group("ver").strip() == "9.9.9", "generated row lost its version")
+        check(m.group("sha") == sha, "generated row lost its hash")
+        check(m.group("fn") == ROW.match(x64).group("fn"),
+              "generated row changed the filename cell")
+
+    # "aaa" sorts before every label in the table, so it must land first
+    first = arm_lines[0].replace(re.match(r"^\|\s*\[([^\]]+)\]", arm_lines[0])
+                                 .group(1), "aaa", 1)
+    out = insert_arm_rows(list(lines), [first])
+    new_at = [i for i, l in enumerate(out) if l == first]
+    check(len(new_at) == 1, "row inserted more than once")
+    if new_at:
+        check(new_at[0] < out.index(arm_lines[1]),
+              "row was not inserted in alphabetical order")
+
+
 def test_arm_same_expands():
     """`arm_outputs: same` is a scalar in tools.yaml; splitting it yields s,a,m,e."""
     for t in load_tools():
@@ -224,6 +254,7 @@ def main():
     test_smoke_cmd_targets_own_binary()
     test_readme_rows_resolve()
     test_readme_matches_binaries()
+    test_arm_row_creation()
     test_arm_same_expands()
     test_version_ordering()
 

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -4,6 +4,10 @@
 usage: update_readme.py NAME=NEWVER [NAME=NEWVER ...]
        update_readme.py --sync            (re-derive every row from the repo)
 
+A tool that starts shipping an ARM binary gets a row created for it in the ARM
+table, copied from its x64 row and inserted alphabetically. Without that a new
+`arm_outputs` ships a binary no table ever mentions.
+
 Rewrites a tool's version and SHA256 cells from tools.yaml and the binary as it
 landed in the repo, per section: the x64 table gets the x64 hash, the ARM table
 the ARM one. Version column keeps its original width so tables stay aligned.
@@ -67,6 +71,42 @@ def sha_of(root, name, arch):
     return h.hexdigest()
 
 
+def _cells(line):
+    """The five raw cells of a table row, padding included."""
+    return line.split("|")[1:6]
+
+
+def _fit(text, width):
+    return f" {text} ".ljust(width)[:max(width, len(text) + 2)]
+
+
+def arm_row(x64_line, arm_lines, ver, sha):
+    """An ARM row for a tool that has only an x64 one, in the ARM table's shape."""
+    src = _cells(x64_line)
+    widths = [len(c) for c in _cells(arm_lines[0])]
+    cells = [src[0], f" {ver} ", src[2], src[3], f" `{sha}` "]
+    return "|" + "|".join(_fit(c.strip(), w) for c, w in zip(cells, widths)) + "|"
+
+
+def insert_arm_rows(lines, additions):
+    """Insert new ARM rows alphabetically by software label."""
+    arm_idx = [i for i, l in enumerate(lines) if ROW.match(l)
+               and i > next(j for j, x in enumerate(lines)
+                            if x.startswith("# Filename map (ARM5)"))]
+    for line in additions:
+        label = re.match(r"^\|\s*\[([^\]]+)\]", line).group(1).lower()
+        at = arm_idx[-1] + 1
+        for i in arm_idx:
+            other = re.match(r"^\|\s*\[([^\]]+)\]", lines[i]).group(1).lower()
+            if other > label:
+                at = i
+                break
+        lines.insert(at, line)
+        arm_idx = [i if i < at else i + 1 for i in arm_idx] + [at]
+        arm_idx.sort()
+    return lines
+
+
 def main():
     tools = load_tools()
     if sys.argv[1:2] == ["--sync"]:
@@ -106,6 +146,28 @@ def main():
             parts[5] = f" `{sha}` "
         lines[i] = "|".join(parts)
         changed.append((section, name, ver, bool(sha)))
+
+    # a tool that just started shipping ARM has no row to update yet
+    have_arm = {name for sec, name, _, _ in changed if sec == "arm"}
+    x64_line = {}
+    for line in lines:                       # x64 table comes first, so its row wins
+        m = ROW.match(line)
+        name = owners.get(m.group("fn").strip("`")) if m else None
+        if name:
+            x64_line.setdefault(name, line)
+    arm_lines = [l for l in lines[next(i for i, x in enumerate(lines)
+                 if x.startswith("# Filename map (ARM5)")):] if ROW.match(l)]
+    additions = []
+    for name, ver in bumps.items():
+        if name in have_arm or name not in x64_line:
+            continue
+        sha = sha_of(ROOT, name, "arm")
+        if not sha:
+            continue
+        additions.append(arm_row(x64_line[name], arm_lines, ver, sha))
+        changed.append(("arm", name, ver, True))
+    if additions:
+        lines = insert_arm_rows(lines, additions)
 
     open(path, "w").write("\n".join(lines))
     for sec, name, ver, hashed in changed:

--- a/tools.yaml
+++ b/tools.yaml
@@ -41,18 +41,21 @@ tools:
     check: {type: github-tag, slug: 3proxy/3proxy}
     lang: c
     outputs: [3proxy]
+    arm_outputs: same
     test_cmd: "timeout 2 /out/x64/3proxy; rc=$?; [ $rc -eq 124 ] || [ $rc -eq 0 ]"
   - name: amass
     version: "5.1.1"
     check: {type: github-release, slug: owasp-amass/amass}
     lang: go
     outputs: [amass]
+    arm_outputs: same
     test: "--version"
   - name: amicontained
     version: "0.4.9"
     check: {type: github-release, slug: genuinetools/amicontained}
     lang: go
     outputs: [amicontained]
+    arm_outputs: same
     test: "--version"
   - name: atop
     version: "2.13.0"
@@ -71,6 +74,7 @@ tools:
     check: {type: github-release, slug: imsnif/bandwhich}
     lang: rust
     outputs: [bandwhich]
+    arm_outputs: same
     test: "--version"
   - name: bbe
     version: "0.2.2"
@@ -83,12 +87,14 @@ tools:
     check: {type: github-release, slug: itchyny/bed}
     lang: go
     outputs: [bed]
+    arm_outputs: same
     test: "--version"
   - name: bit
     version: "1.1.2"
     check: {type: github-release, slug: chriswalz/bit}
     lang: go
     outputs: [bit]
+    arm_outputs: same
     test: "version"
   - name: boringtun
     version: "0.5.2"
@@ -100,6 +106,7 @@ tools:
       - bin: wg-user
         dst: wg-user
         note: legacy boringtun-cli alias kept for backwards compatibility
+    arm_outputs: same
     test: "--version"
   - name: brook
     version: "20260101.0"
@@ -123,6 +130,7 @@ tools:
     check: {type: github-tag, slug: bryanpkc/corkscrew}
     lang: c
     outputs: [corkscrew]
+    arm_outputs: same
     test_cmd: '/out/x64/corkscrew -h 2>&1 | grep -qiE "usage|corkscrew" || /out/x64/corkscrew 2>&1 | grep -qiE "usage|corkscrew"'
   - name: curl
     version: "8.21.0"
@@ -150,12 +158,14 @@ tools:
     check: {type: github-release, slug: mosajjal/dnspot}
     lang: go
     outputs: [dnspot-agent, dnspot-server]
+    arm_outputs: same
     test: "--version"
   - name: dnstrace
     version: "1.4.3"
     check: {type: github-release, slug: rs/dnstrace}
     lang: go
     outputs: [dnstrace]
+    arm_outputs: same
     test_cmd: '/out/x64/dnstrace -h 2>&1 | grep -qiE "usage|query"'
   - name: dnstt_client
     version: "1.20260501.0"
@@ -176,12 +186,17 @@ tools:
     check: {type: github-tag, slug: mkj/dropbear, pattern: '^DROPBEAR_(\d+\.\d+)$', transform: underscore_to_dot}
     lang: c
     outputs: [dropbear, dbclient, dropbearconvert, dropbearkey, scp]
+    # ARM ships these flat, unlike x64/dropbear/
+    arm_outputs: [{bin: dropbear, dst: dropbear}, {bin: dbclient, dst: dbclient},
+                  {bin: dropbearconvert, dst: dropbearconvert},
+                  {bin: dropbearkey, dst: dropbearkey}, {bin: scp, dst: scp}]
     test_cmd: "/out/x64/dbclient -V 2>&1 | grep -qi dropbear"
   - name: dsvpn
     version: "0.1.5"
     check: {type: github-release, slug: jedisct1/dsvpn}
     lang: c
     outputs: [dsvpn]
+    arm_outputs: same
     test_cmd: "/out/x64/dsvpn 2>&1 | grep -qi 'usage\\|dsvpn'"
   - name: es-dump
     version: "1.0.7"
@@ -222,6 +237,7 @@ tools:
     check: {type: github-release, slug: wader/fq}
     lang: go
     outputs: [fq]
+    arm_outputs: same
     test: "--version"
   - name: frp
     version: "0.71.0"
@@ -249,6 +265,7 @@ tools:
     check: {type: github-release, slug: OJ/gobuster}
     lang: go
     outputs: [gobuster]
+    arm_outputs: same
     test: "--version"
   - name: gojq
     version: "0.12.19"
@@ -283,6 +300,7 @@ tools:
     check: {type: github-release, slug: pemistahl/grex}
     lang: rust
     outputs: [grex]
+    arm_outputs: same
     test: "--version"
   - name: gum
     version: "2.0.0"
@@ -308,6 +326,7 @@ tools:
     check: {type: pinned, reason: upstream has no tags or releases}
     lang: go
     outputs: [httpdump]
+    arm_outputs: same
     test: "--help"
   - name: httptunnel_client
     version: "3.3"
@@ -330,18 +349,21 @@ tools:
     check: {type: github-release, slug: sitkevij/hex}
     lang: rust
     outputs: [hex]
+    arm_outputs: same
     test: "--version"
   - name: icmptunnel
     version: "1.0.0"
     check: {type: github-tag, slug: DhavalKapil/icmptunnel, prefix: v}
     lang: c
     outputs: [icmptunnel]
+    arm_outputs: same
     test_cmd: "/out/x64/icmptunnel -h 2>&1 | grep -qi tunnel"
   - name: inlets
     version: "3.0"
     check: {type: pinned, reason: original repo deleted; the-cc-dev/inlets is a mirror}
     lang: go
     outputs: [inlets]
+    arm_outputs: same
     test: "--version"
   - name: iodine
     version: "0.8.0"
@@ -354,6 +376,7 @@ tools:
     check: {type: github-tag, slug: koct9i/ioping, prefix: v}
     lang: c
     outputs: [ioping]
+    arm_outputs: same
     test: "--version"
   - name: jaq
     version: "3.1.1"
@@ -366,6 +389,7 @@ tools:
     check: {type: github-release, slug: tidwall/jj}
     lang: go
     outputs: [jj]
+    arm_outputs: same
     test: "-h"
   - name: jq
     version: "1.8.2"
@@ -379,12 +403,14 @@ tools:
     check: {type: github-release, slug: ilai-deutel/kibi}
     lang: rust
     outputs: [kibi]
+    arm_outputs: same
     test: "--version"
   - name: kmon
     version: "1.7.1"
     check: {type: github-release, slug: orhun/kmon}
     lang: rust
     outputs: [kmon]
+    arm_outputs: same
     test: "--version"
   - name: lazygit
     version: "0.64.1"
@@ -411,12 +437,14 @@ tools:
     check: {type: github-release, slug: laurent22/massren}
     lang: go
     outputs: [massren]
+    arm_outputs: same
     test: "--version"
   - name: memcd-util
     version: "0.0.1"
     check: {type: github-release, slug: me-io/memcached-util}
     lang: go
     outputs: [memcd-util]
+    arm_outputs: same
     test: "--version"
     experimental: true
   - name: merino
@@ -424,6 +452,7 @@ tools:
     check: {type: pinned, reason: no tags/releases upstream}
     lang: rust
     outputs: [merino]
+    arm_outputs: same
     test: "--version"
   - name: micro
     version: "2.0.15"
@@ -500,6 +529,7 @@ tools:
     check: {type: github-release, slug: yaa110/nomino}
     lang: rust
     outputs: [nomino]
+    arm_outputs: same
     test: "--version"
   - name: onionpipe
     version: "1.1.11"
@@ -572,6 +602,7 @@ tools:
     check: {type: github-release, slug: lotabout/rargs}
     lang: rust
     outputs: [rargs]
+    arm_outputs: same
     test: "--help"
   - name: redir
     version: "3.3"
@@ -590,6 +621,7 @@ tools:
     check: {type: github-release, slug: chmln/sd}
     lang: rust
     outputs: [sd]
+    arm_outputs: same
     test_cmd: "/out/x64/sd --version"
   - name: singbox
     version: "1.14.0"
@@ -692,6 +724,7 @@ tools:
     check: {type: github-release, slug: osa1/tiny, prefix: v}
     lang: rust
     outputs: [tiny]
+    arm_outputs: same
     test: "--version"
     experimental: true
   - name: tinyproxy
@@ -778,12 +811,14 @@ tools:
     check: {type: github-tag, slug: vim/vim, pattern: '^v(\d+\.\d+\.\d{4})$'}
     lang: c
     outputs: [xxd]
+    arm_outputs: same
     test: "--version"
   - name: yq
     version: "4.53.6"
     check: {type: github-release, slug: mikefarah/yq, prefix: v}
     lang: go
     outputs: [yq]
+    arm_outputs: same
     test_cmd: "/out/x64/yq '.a' /dev/null --null-input || true; echo '{}' | /out/x64/yq -P '.'"
   - name: zenith
     version: "0.12.0"


### PR DESCRIPTION
32 tools cross-compile an ARMv7 binary, smoke-test it, and throw it away — the
manifest never declared `arm_outputs` for them: `amass`, `bandwhich`, `fq`,
`gobuster`, `grex`, `hex`, `kibi`, `kmon`, `sd`, `xxd`, `yq`, `3proxy`, `dsvpn`,
`icmptunnel` and 18 more.

`dropbear` is the sharpest case: its ARM binaries are **already in the repo** and have
gone stale, because no bump could ever touch what the manifest didn't list. It also
ships its ARM set flat, unlike `x64/dropbear/`, so it declares explicit destinations
instead of mirroring x64 — `scripts/test_layout.py` caught that immediately.

`update_readme.py` can now create an ARM row for a tool that only has an x64 one,
copied from it and inserted alphabetically. Without that, a new `arm_outputs` ships a
binary no table mentions.

This PR is the manifest and tooling only. The binaries follow from a forced bump run
once it lands, which builds all 32 and lets `apply_bump.sh` place them and write their
rows — roughly 40 MB added to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)