### PR TITLE
Fail a build that produces a dynamic binary

### DIFF
--- a/build/3proxy/Dockerfile
+++ b/build/3proxy/Dockerfile
@@ -28,6 +28,7 @@ RUN set -ex \
  && for f in "/out/x64/3proxy"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/3proxy"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/3proxy" "/out/arm/3proxy" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/3proxy" "/out/arm/3proxy"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/3proxy" "/out/arm/3proxy" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/amass/Dockerfile
+++ b/build/amass/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/amass) && cp /tmp/x64_amass /out/x64/amass \
  && mkdir -p $(dirname /out/arm/amass) && cp /tmp/arm_amass /out/arm/amass \
  && test -n "$(ls "/out/x64/amass" "/out/arm/amass" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/amass" "/out/arm/amass"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/amass" "/out/arm/amass" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/amicontained/Dockerfile
+++ b/build/amicontained/Dockerfile
@@ -14,6 +14,7 @@ RUN set -ex \
 RUN set -ex \
  && mkdir -p $(dirname /out/x64/amicontained) && cp /tmp/x64_amicontained /out/x64/amicontained \
  && test -n "$(ls "/out/x64/amicontained" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/amicontained"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/amicontained" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/atop/Dockerfile
+++ b/build/atop/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/atop) && cp /tmp/out/atop /out/x64/atop \
  && for f in "/out/x64/atop"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/atop" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/atop"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/atop" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/avml/Dockerfile
+++ b/build/avml/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/avml) && cp /tmp/x64_avml /out/x64/avml \
  && for f in "/out/x64/avml"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/avml" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/avml"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/avml" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/bandwhich/Dockerfile
+++ b/build/bandwhich/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
  && for f in "/out/x64/bandwhich"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/bandwhich"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/bandwhich" "/out/arm/bandwhich" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/bandwhich" "/out/arm/bandwhich"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/bandwhich" "/out/arm/bandwhich" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/bbe/Dockerfile
+++ b/build/bbe/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/bbe) && cp /tmp/out/bbe /out/x64/bbe \
  && for f in "/out/x64/bbe"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/bbe" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/bbe"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/bbe" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/bed/Dockerfile
+++ b/build/bed/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/bed) && cp /tmp/x64_bed /out/x64/bed \
  && mkdir -p $(dirname /out/arm/bed) && cp /tmp/arm_bed /out/arm/bed \
  && test -n "$(ls "/out/x64/bed" "/out/arm/bed" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/bed" "/out/arm/bed"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/bed" "/out/arm/bed" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/bit/Dockerfile
+++ b/build/bit/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/bit) && cp /tmp/x64_bit /out/x64/bit \
  && mkdir -p $(dirname /out/arm/bit) && cp /tmp/arm_bit /out/arm/bit \
  && test -n "$(ls "/out/x64/bit" "/out/arm/bit" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/bit" "/out/arm/bit"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/bit" "/out/arm/bit" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/boringtun/Dockerfile
+++ b/build/boringtun/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex \
  && for f in "/out/x64/boringtun" "/out/x64/wg-user"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/boringtun" "/out/arm/wg-user"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/boringtun" "/out/x64/wg-user" "/out/arm/boringtun" "/out/arm/wg-user" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/boringtun" "/out/x64/wg-user" "/out/arm/boringtun" "/out/arm/wg-user"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/boringtun" "/out/x64/wg-user" "/out/arm/boringtun" "/out/arm/wg-user" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/brook/Dockerfile
+++ b/build/brook/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/brook) && cp /tmp/x64_brook /out/x64/brook \
  && mkdir -p $(dirname /out/arm/brook) && cp /tmp/arm_brook /out/arm/brook \
  && test -n "$(ls "/out/x64/brook" "/out/arm/brook" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/brook" "/out/arm/brook"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/brook" "/out/arm/brook" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/busybox/Dockerfile
+++ b/build/busybox/Dockerfile
@@ -34,6 +34,7 @@ RUN set -ex \
  && for f in "/out/x64/busybox"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/busybox"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/busybox" "/out/arm/busybox" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/busybox" "/out/arm/busybox"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/busybox" "/out/arm/busybox" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/corkscrew/Dockerfile
+++ b/build/corkscrew/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
  && for f in "/out/x64/corkscrew"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/corkscrew"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/corkscrew" "/out/arm/corkscrew" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/corkscrew" "/out/arm/corkscrew"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/corkscrew" "/out/arm/corkscrew" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/curl/Dockerfile
+++ b/build/curl/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/curl) && cp /tmp/out/curl /out/x64/curl \
  && for f in "/out/x64/curl"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/curl" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/curl"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/curl" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/dh/Dockerfile
+++ b/build/dh/Dockerfile
@@ -25,6 +25,7 @@ RUN set -ex \
  && for f in "/out/x64/dh"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/dh"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/dh" "/out/arm/dh" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/dh" "/out/arm/dh"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/dh" "/out/arm/dh" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/dnsmonster/Dockerfile
+++ b/build/dnsmonster/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
 RUN set -ex \
  && mkdir -p $(dirname /out/x64/dnsmonster) && cp /tmp/x64_dnsmonster /out/x64/dnsmonster \
  && test -n "$(ls "/out/x64/dnsmonster" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/dnsmonster"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/dnsmonster" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/dnspot/Dockerfile
+++ b/build/dnspot/Dockerfile
@@ -22,6 +22,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/arm/dnspot-agent) && cp /tmp/arm_dnspot-agent /out/arm/dnspot-agent \
  && mkdir -p $(dirname /out/arm/dnspot-server) && cp /tmp/arm_dnspot-server /out/arm/dnspot-server \
  && test -n "$(ls "/out/x64/dnspot-agent" "/out/x64/dnspot-server" "/out/arm/dnspot-agent" "/out/arm/dnspot-server" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/dnspot-agent" "/out/x64/dnspot-server" "/out/arm/dnspot-agent" "/out/arm/dnspot-server"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/dnspot-agent" "/out/x64/dnspot-server" "/out/arm/dnspot-agent" "/out/arm/dnspot-server" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/dnstrace/Dockerfile
+++ b/build/dnstrace/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/dnstrace) && cp /tmp/x64_dnstrace /out/x64/dnstrace \
  && mkdir -p $(dirname /out/arm/dnstrace) && cp /tmp/arm_dnstrace /out/arm/dnstrace \
  && test -n "$(ls "/out/x64/dnstrace" "/out/arm/dnstrace" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/dnstrace" "/out/arm/dnstrace"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/dnstrace" "/out/arm/dnstrace" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/dnstt_client/Dockerfile
+++ b/build/dnstt_client/Dockerfile
@@ -22,6 +22,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/arm/dnstt_client) && cp /tmp/arm_dnstt_client /out/arm/dnstt_client \
  && mkdir -p $(dirname /out/arm/dnstt_server) && cp /tmp/arm_dnstt_server /out/arm/dnstt_server \
  && test -n "$(ls "/out/x64/dnstt_client" "/out/x64/dnstt_server" "/out/arm/dnstt_client" "/out/arm/dnstt_server" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/dnstt_client" "/out/x64/dnstt_server" "/out/arm/dnstt_client" "/out/arm/dnstt_server"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/dnstt_client" "/out/x64/dnstt_server" "/out/arm/dnstt_client" "/out/arm/dnstt_server" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/doggo/Dockerfile
+++ b/build/doggo/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/doggo) && cp /tmp/x64_doggo /out/x64/doggo \
  && mkdir -p $(dirname /out/arm/doggo) && cp /tmp/arm_doggo /out/arm/doggo \
  && test -n "$(ls "/out/x64/doggo" "/out/arm/doggo" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/doggo" "/out/arm/doggo"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/doggo" "/out/arm/doggo" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/dropbear/Dockerfile
+++ b/build/dropbear/Dockerfile
@@ -38,6 +38,7 @@ RUN set -ex \
  && for f in "/out/x64/dropbear" "/out/x64/dbclient" "/out/x64/dropbearconvert" "/out/x64/dropbearkey" "/out/x64/scp"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/dropbear" "/out/arm/dbclient" "/out/arm/dropbearconvert" "/out/arm/dropbearkey" "/out/arm/scp"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/dropbear" "/out/x64/dbclient" "/out/x64/dropbearconvert" "/out/x64/dropbearkey" "/out/x64/scp" "/out/arm/dropbear" "/out/arm/dbclient" "/out/arm/dropbearconvert" "/out/arm/dropbearkey" "/out/arm/scp" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/dropbear" "/out/x64/dbclient" "/out/x64/dropbearconvert" "/out/x64/dropbearkey" "/out/x64/scp" "/out/arm/dropbear" "/out/arm/dbclient" "/out/arm/dropbearconvert" "/out/arm/dropbearkey" "/out/arm/scp"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/dropbear" "/out/x64/dbclient" "/out/x64/dropbearconvert" "/out/x64/dropbearkey" "/out/x64/scp" "/out/arm/dropbear" "/out/arm/dbclient" "/out/arm/dropbearconvert" "/out/arm/dropbearkey" "/out/arm/scp" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/dsvpn/Dockerfile
+++ b/build/dsvpn/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex \
  && for f in "/out/x64/dsvpn"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/dsvpn"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/dsvpn" "/out/arm/dsvpn" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/dsvpn" "/out/arm/dsvpn"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/dsvpn" "/out/arm/dsvpn" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/es-dump/Dockerfile
+++ b/build/es-dump/Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex \
 RUN set -ex \
  && mkdir -p $(dirname /out/x64/es-dump) && cp /tmp/x64_es-dump /out/x64/es-dump \
  && test -n "$(ls "/out/x64/es-dump" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/es-dump"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/es-dump" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/evtx/Dockerfile
+++ b/build/evtx/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/evtx) && cp /tmp/x64_evtx /out/x64/evtx \
  && for f in "/out/x64/evtx"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/evtx" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/evtx"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/evtx" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/fd/Dockerfile
+++ b/build/fd/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
  && for f in "/out/x64/fd"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/fd"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/fd" "/out/arm/fd" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/fd" "/out/arm/fd"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/fd" "/out/arm/fd" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/ffuf/Dockerfile
+++ b/build/ffuf/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/ffuf) && cp /tmp/x64_ffuf /out/x64/ffuf \
  && mkdir -p $(dirname /out/arm/ffuf) && cp /tmp/arm_ffuf /out/arm/ffuf \
  && test -n "$(ls "/out/x64/ffuf" "/out/arm/ffuf" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/ffuf" "/out/arm/ffuf"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/ffuf" "/out/arm/ffuf" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/fish/Dockerfile
+++ b/build/fish/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/fish) && cp /tmp/out/fish /out/x64/fish \
  && for f in "/out/x64/fish"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/fish" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/fish"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/fish" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/fq/Dockerfile
+++ b/build/fq/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/fq) && cp /tmp/x64_fq /out/x64/fq \
  && mkdir -p $(dirname /out/arm/fq) && cp /tmp/arm_fq /out/arm/fq \
  && test -n "$(ls "/out/x64/fq" "/out/arm/fq" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/fq" "/out/arm/fq"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/fq" "/out/arm/fq" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/frp/Dockerfile
+++ b/build/frp/Dockerfile
@@ -24,6 +24,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/arm/frpc) && cp /tmp/arm_frpc /out/arm/frpc \
  && mkdir -p $(dirname /out/arm/frps) && cp /tmp/arm_frps /out/arm/frps \
  && test -n "$(ls "/out/x64/frpc" "/out/x64/frps" "/out/arm/frpc" "/out/arm/frps" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/frpc" "/out/x64/frps" "/out/arm/frpc" "/out/arm/frps"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/frpc" "/out/x64/frps" "/out/arm/frpc" "/out/arm/frps" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/fzf/Dockerfile
+++ b/build/fzf/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/fzf) && cp /tmp/x64_fzf /out/x64/fzf \
  && mkdir -p $(dirname /out/arm/fzf) && cp /tmp/arm_fzf /out/arm/fzf \
  && test -n "$(ls "/out/x64/fzf" "/out/arm/fzf" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/fzf" "/out/arm/fzf"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/fzf" "/out/arm/fzf" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/ghfs/Dockerfile
+++ b/build/ghfs/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/ghfs) && cp /tmp/x64_ghfs /out/x64/ghfs \
  && mkdir -p $(dirname /out/arm/ghfs) && cp /tmp/arm_ghfs /out/arm/ghfs \
  && test -n "$(ls "/out/x64/ghfs" "/out/arm/ghfs" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/ghfs" "/out/arm/ghfs"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/ghfs" "/out/arm/ghfs" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/gobuster/Dockerfile
+++ b/build/gobuster/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/gobuster) && cp /tmp/x64_gobuster /out/x64/gobuster \
  && mkdir -p $(dirname /out/arm/gobuster) && cp /tmp/arm_gobuster /out/arm/gobuster \
  && test -n "$(ls "/out/x64/gobuster" "/out/arm/gobuster" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/gobuster" "/out/arm/gobuster"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/gobuster" "/out/arm/gobuster" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/gojq/Dockerfile
+++ b/build/gojq/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/gojq) && cp /tmp/x64_gojq /out/x64/gojq \
  && mkdir -p $(dirname /out/arm/gojq) && cp /tmp/arm_gojq /out/arm/gojq \
  && test -n "$(ls "/out/x64/gojq" "/out/arm/gojq" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/gojq" "/out/arm/gojq"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/gojq" "/out/arm/gojq" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/goss/Dockerfile
+++ b/build/goss/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/goss) && cp /tmp/x64_goss /out/x64/goss \
  && mkdir -p $(dirname /out/arm/goss) && cp /tmp/arm_goss /out/arm/goss \
  && test -n "$(ls "/out/x64/goss" "/out/arm/goss" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/goss" "/out/arm/goss"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/goss" "/out/arm/goss" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/gotop/Dockerfile
+++ b/build/gotop/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/gotop) && cp /tmp/x64_gotop /out/x64/gotop \
  && mkdir -p $(dirname /out/arm/gotop) && cp /tmp/arm_gotop /out/arm/gotop \
  && test -n "$(ls "/out/x64/gotop" "/out/arm/gotop" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/gotop" "/out/arm/gotop"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/gotop" "/out/arm/gotop" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/grex/Dockerfile
+++ b/build/grex/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
  && for f in "/out/x64/grex"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/grex"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/grex" "/out/arm/grex" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/grex" "/out/arm/grex"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/grex" "/out/arm/grex" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/gron/Dockerfile
+++ b/build/gron/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/gron) && cp /tmp/x64_gron /out/x64/gron \
  && mkdir -p $(dirname /out/arm/gron) && cp /tmp/arm_gron /out/arm/gron \
  && test -n "$(ls "/out/x64/gron" "/out/arm/gron" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/gron" "/out/arm/gron"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/gron" "/out/arm/gron" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/gum/Dockerfile
+++ b/build/gum/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/gum) && cp /tmp/x64_gum /out/x64/gum \
  && mkdir -p $(dirname /out/arm/gum) && cp /tmp/arm_gum /out/arm/gum \
  && test -n "$(ls "/out/x64/gum" "/out/arm/gum" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/gum" "/out/arm/gum"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/gum" "/out/arm/gum" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/hex/Dockerfile
+++ b/build/hex/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
  && for f in "/out/x64/hex"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/hex"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/hex" "/out/arm/hex" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/hex" "/out/arm/hex"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/hex" "/out/arm/hex" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/htop/Dockerfile
+++ b/build/htop/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/htop) && cp /tmp/out/htop /out/x64/htop \
  && for f in "/out/x64/htop"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/htop" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/htop"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/htop" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/httpdump/Dockerfile
+++ b/build/httpdump/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
 RUN set -ex \
  && mkdir -p $(dirname /out/x64/httpdump) && cp /tmp/x64_httpdump /out/x64/httpdump \
  && test -n "$(ls "/out/x64/httpdump" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/httpdump"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/httpdump" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/httptunnel_client/Dockerfile
+++ b/build/httptunnel_client/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/httptunnel-server) && cp /tmp/out/httptunnel-server /out/x64/httptunnel-server \
  && for f in "/out/x64/httptunnel-client" "/out/x64/httptunnel-server"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/httptunnel-client" "/out/x64/httptunnel-server" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/httptunnel-client" "/out/x64/httptunnel-server"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/httptunnel-client" "/out/x64/httptunnel-server" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/httpx/Dockerfile
+++ b/build/httpx/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/httpx) && cp /tmp/x64_httpx /out/x64/httpx \
  && mkdir -p $(dirname /out/arm/httpx) && cp /tmp/arm_httpx /out/arm/httpx \
  && test -n "$(ls "/out/x64/httpx" "/out/arm/httpx" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/httpx" "/out/arm/httpx"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/httpx" "/out/arm/httpx" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/hx/Dockerfile
+++ b/build/hx/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/hx) && cp /tmp/x64_hx /out/x64/hx \
  && for f in "/out/x64/hx"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/hx" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/hx"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/hx" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/icmptunnel/Dockerfile
+++ b/build/icmptunnel/Dockerfile
@@ -28,6 +28,7 @@ RUN set -ex \
  && for f in "/out/x64/icmptunnel"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/icmptunnel"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/icmptunnel" "/out/arm/icmptunnel" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/icmptunnel" "/out/arm/icmptunnel"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/icmptunnel" "/out/arm/icmptunnel" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/inlets/Dockerfile
+++ b/build/inlets/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/inlets) && cp /tmp/x64_inlets /out/x64/inlets \
  && mkdir -p $(dirname /out/arm/inlets) && cp /tmp/arm_inlets /out/arm/inlets \
  && test -n "$(ls "/out/x64/inlets" "/out/arm/inlets" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/inlets" "/out/arm/inlets"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/inlets" "/out/arm/inlets" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/iodine/Dockerfile
+++ b/build/iodine/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/iodined) && cp /tmp/out/iodined /out/x64/iodined \
  && for f in "/out/x64/iodine" "/out/x64/iodined"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/iodine" "/out/x64/iodined" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/iodine" "/out/x64/iodined"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/iodine" "/out/x64/iodined" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/ioping/Dockerfile
+++ b/build/ioping/Dockerfile
@@ -28,6 +28,7 @@ RUN set -ex \
  && for f in "/out/x64/ioping"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/ioping"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/ioping" "/out/arm/ioping" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/ioping" "/out/arm/ioping"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/ioping" "/out/arm/ioping" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/jaq/Dockerfile
+++ b/build/jaq/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/jaq) && cp /tmp/x64_jaq /out/x64/jaq \
  && for f in "/out/x64/jaq"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/jaq" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/jaq"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/jaq" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/jj/Dockerfile
+++ b/build/jj/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/jj) && cp /tmp/x64_jj /out/x64/jj \
  && mkdir -p $(dirname /out/arm/jj) && cp /tmp/arm_jj /out/arm/jj \
  && test -n "$(ls "/out/x64/jj" "/out/arm/jj" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/jj" "/out/arm/jj"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/jj" "/out/arm/jj" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/jq/Dockerfile
+++ b/build/jq/Dockerfile
@@ -30,6 +30,7 @@ RUN set -ex \
  && for f in "/out/x64/jq"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/jq"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/jq" "/out/arm/jq" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/jq" "/out/arm/jq"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/jq" "/out/arm/jq" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/kibi/Dockerfile
+++ b/build/kibi/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
  && for f in "/out/x64/kibi"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/kibi"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/kibi" "/out/arm/kibi" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/kibi" "/out/arm/kibi"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/kibi" "/out/arm/kibi" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/kmon/Dockerfile
+++ b/build/kmon/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
  && for f in "/out/x64/kmon"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/kmon"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/kmon" "/out/arm/kmon" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/kmon" "/out/arm/kmon"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/kmon" "/out/arm/kmon" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/lazygit/Dockerfile
+++ b/build/lazygit/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/lazygit) && cp /tmp/x64_lazygit /out/x64/lazygit \
  && mkdir -p $(dirname /out/arm/lazygit) && cp /tmp/arm_lazygit /out/arm/lazygit \
  && test -n "$(ls "/out/x64/lazygit" "/out/arm/lazygit" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/lazygit" "/out/arm/lazygit"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/lazygit" "/out/arm/lazygit" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/lnav/Dockerfile
+++ b/build/lnav/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/lnav) && cp /tmp/out/lnav /out/x64/lnav \
  && for f in "/out/x64/lnav"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/lnav" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/lnav"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/lnav" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/logtop/Dockerfile
+++ b/build/logtop/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/logtop) && cp /tmp/out/logtop /out/x64/logtop \
  && for f in "/out/x64/logtop"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/logtop" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/logtop"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/logtop" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/massren/Dockerfile
+++ b/build/massren/Dockerfile
@@ -24,6 +24,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/massren) && cp /tmp/x64_massren /out/x64/massren \
  && mkdir -p $(dirname /out/arm/massren) && cp /tmp/arm_massren /out/arm/massren \
  && test -n "$(ls "/out/x64/massren" "/out/arm/massren" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/massren" "/out/arm/massren"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/massren" "/out/arm/massren" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/memcd-util/Dockerfile
+++ b/build/memcd-util/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/memcd-util) && cp /tmp/x64_memcd-util /out/x64/memcd-util \
  && mkdir -p $(dirname /out/arm/memcd-util) && cp /tmp/arm_memcd-util /out/arm/memcd-util \
  && test -n "$(ls "/out/x64/memcd-util" "/out/arm/memcd-util" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/memcd-util" "/out/arm/memcd-util"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/memcd-util" "/out/arm/memcd-util" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/merino/Dockerfile
+++ b/build/merino/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
  && for f in "/out/x64/merino"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/merino"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/merino" "/out/arm/merino" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/merino" "/out/arm/merino"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/merino" "/out/arm/merino" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/micro/Dockerfile
+++ b/build/micro/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/micro) && cp /tmp/x64_micro /out/x64/micro \
  && mkdir -p $(dirname /out/arm/micro) && cp /tmp/arm_micro /out/arm/micro \
  && test -n "$(ls "/out/x64/micro" "/out/arm/micro" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/micro" "/out/arm/micro"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/micro" "/out/arm/micro" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/miniserve/Dockerfile
+++ b/build/miniserve/Dockerfile
@@ -34,6 +34,7 @@ RUN set -ex \
  && for f in "/out/x64/miniserve"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/miniserve"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/miniserve" "/out/arm/miniserve" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/miniserve" "/out/arm/miniserve"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/miniserve" "/out/arm/miniserve" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/mylg/Dockerfile
+++ b/build/mylg/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
 RUN set -ex \
  && mkdir -p $(dirname /out/x64/mylg) && cp /tmp/x64_mylg /out/x64/mylg \
  && test -n "$(ls "/out/x64/mylg" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/mylg"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/mylg" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/nano/Dockerfile
+++ b/build/nano/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/nano) && cp /tmp/out/nano /out/x64/nano \
  && for f in "/out/x64/nano"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/nano" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/nano"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/nano" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/ncdu/Dockerfile
+++ b/build/ncdu/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/ncdu) && cp /tmp/out/ncdu /out/x64/ncdu \
  && for f in "/out/x64/ncdu"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/ncdu" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/ncdu"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/ncdu" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/netsniff/Dockerfile
+++ b/build/netsniff/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/ifpps) && cp /tmp/out/ifpps /out/x64/ifpps \
  && for f in "/out/x64/netsniff-ng" "/out/x64/ifpps"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/netsniff-ng" "/out/x64/ifpps" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/netsniff-ng" "/out/x64/ifpps"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/netsniff-ng" "/out/x64/ifpps" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/ngrep/Dockerfile
+++ b/build/ngrep/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/ngrep) && cp /tmp/out/ngrep /out/x64/ngrep \
  && for f in "/out/x64/ngrep"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/ngrep" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/ngrep"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/ngrep" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/nmap/Dockerfile
+++ b/build/nmap/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/nping) && cp /tmp/out/nping /out/x64/nping \
  && for f in "/out/x64/nmap" "/out/x64/nping"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/nmap" "/out/x64/nping" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/nmap" "/out/x64/nping"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/nmap" "/out/x64/nping" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/nomino/Dockerfile
+++ b/build/nomino/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
  && for f in "/out/x64/nomino"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/nomino"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/nomino" "/out/arm/nomino" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/nomino" "/out/arm/nomino"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/nomino" "/out/arm/nomino" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/onionpipe/Dockerfile
+++ b/build/onionpipe/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/onionpipe) && cp /tmp/x64_onionpipe /out/x64/onionpipe \
  && mkdir -p $(dirname /out/arm/onionpipe) && cp /tmp/arm_onionpipe /out/arm/onionpipe \
  && test -n "$(ls "/out/x64/onionpipe" "/out/arm/onionpipe" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/onionpipe" "/out/arm/onionpipe"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/onionpipe" "/out/arm/onionpipe" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/openrsync/Dockerfile
+++ b/build/openrsync/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/openrsync) && cp /tmp/out/openrsync /out/x64/openrsync \
  && for f in "/out/x64/openrsync"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/openrsync" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/openrsync"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/openrsync" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/packetq/Dockerfile
+++ b/build/packetq/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/packetq) && cp /tmp/out/packetq /out/x64/packetq \
  && for f in "/out/x64/packetq"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/packetq" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/packetq"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/packetq" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/pdns/Dockerfile
+++ b/build/pdns/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/pdns) && cp /tmp/out/pdns /out/x64/pdns \
  && for f in "/out/x64/pdns"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/pdns" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/pdns"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/pdns" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/pline-go/Dockerfile
+++ b/build/pline-go/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/pline-go) && cp /tmp/x64_pline-go /out/x64/pline-go \
  && mkdir -p $(dirname /out/arm/pline-go) && cp /tmp/arm_pline-go /out/arm/pline-go \
  && test -n "$(ls "/out/x64/pline-go" "/out/arm/pline-go" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/pline-go" "/out/arm/pline-go"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/pline-go" "/out/arm/pline-go" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/pt_bridges/Dockerfile
+++ b/build/pt_bridges/Dockerfile
@@ -22,6 +22,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/webtunnel_client) && cp /tmp/x64_webtunnel_client /out/x64/webtunnel_client \
  && mkdir -p $(dirname /out/x64/webtunnel_server) && cp /tmp/x64_webtunnel_server /out/x64/webtunnel_server \
  && test -n "$(ls "/out/x64/snowflake" "/out/x64/lyrebird" "/out/x64/webtunnel_client" "/out/x64/webtunnel_server" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/snowflake" "/out/x64/lyrebird" "/out/x64/webtunnel_client" "/out/x64/webtunnel_server"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/snowflake" "/out/x64/lyrebird" "/out/x64/webtunnel_client" "/out/x64/webtunnel_server" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/ptunnel-ng/Dockerfile
+++ b/build/ptunnel-ng/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/ptunnel-ng) && cp /tmp/out/ptunnel-ng /out/x64/ptunnel-ng \
  && for f in "/out/x64/ptunnel-ng"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/ptunnel-ng" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/ptunnel-ng"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/ptunnel-ng" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/pueue/Dockerfile
+++ b/build/pueue/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/pueued) && cp /tmp/x64_pueued /out/x64/pueued \
  && for f in "/out/x64/pueue" "/out/x64/pueued"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/pueue" "/out/x64/pueued" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/pueue" "/out/x64/pueued"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/pueue" "/out/x64/pueued" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/pv/Dockerfile
+++ b/build/pv/Dockerfile
@@ -30,6 +30,7 @@ RUN set -ex \
  && for f in "/out/x64/pv"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/pv"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/pv" "/out/arm/pv" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/pv" "/out/arm/pv"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/pv" "/out/arm/pv" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/q/Dockerfile
+++ b/build/q/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/q) && cp /tmp/x64_q /out/x64/q \
  && mkdir -p $(dirname /out/arm/q) && cp /tmp/arm_q /out/arm/q \
  && test -n "$(ls "/out/x64/q" "/out/arm/q" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/q" "/out/arm/q"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/q" "/out/arm/q" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/rargs/Dockerfile
+++ b/build/rargs/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
  && for f in "/out/x64/rargs"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/rargs"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/rargs" "/out/arm/rargs" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/rargs" "/out/arm/rargs"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/rargs" "/out/arm/rargs" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/redir/Dockerfile
+++ b/build/redir/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/redir) && cp /tmp/out/redir /out/x64/redir \
  && for f in "/out/x64/redir"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/redir" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/redir"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/redir" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/rg/Dockerfile
+++ b/build/rg/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/rg) && cp /tmp/x64_rg /out/x64/rg \
  && for f in "/out/x64/rg"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/rg" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/rg"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/rg" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/sd/Dockerfile
+++ b/build/sd/Dockerfile
@@ -32,6 +32,7 @@ RUN set -ex \
  && for f in "/out/x64/sd"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/sd"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/sd" "/out/arm/sd" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/sd" "/out/arm/sd"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/sd" "/out/arm/sd" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/singbox/Dockerfile
+++ b/build/singbox/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/singbox) && cp /tmp/x64_singbox /out/x64/singbox \
  && mkdir -p $(dirname /out/arm/singbox) && cp /tmp/arm_singbox /out/arm/singbox \
  && test -n "$(ls "/out/x64/singbox" "/out/arm/singbox" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/singbox" "/out/arm/singbox"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/singbox" "/out/arm/singbox" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/sniproxy/Dockerfile
+++ b/build/sniproxy/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/sniproxy) && cp /tmp/x64_sniproxy /out/x64/sniproxy \
  && mkdir -p $(dirname /out/arm/sniproxy) && cp /tmp/arm_sniproxy /out/arm/sniproxy \
  && test -n "$(ls "/out/x64/sniproxy" "/out/arm/sniproxy" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/sniproxy" "/out/arm/sniproxy"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/sniproxy" "/out/arm/sniproxy" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/socat/Dockerfile
+++ b/build/socat/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/socat) && cp /tmp/out/socat /out/x64/socat \
  && for f in "/out/x64/socat"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/socat" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/socat"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/socat" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/spp/Dockerfile
+++ b/build/spp/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/spp) && cp /tmp/x64_spp /out/x64/spp \
  && mkdir -p $(dirname /out/arm/spp) && cp /tmp/arm_spp /out/arm/spp \
  && test -n "$(ls "/out/x64/spp" "/out/arm/spp" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/spp" "/out/arm/spp"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/spp" "/out/arm/spp" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/sshx/Dockerfile
+++ b/build/sshx/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/sshx-server) && cp /tmp/x64_sshx-server /out/x64/sshx-server \
  && for f in "/out/x64/sshx" "/out/x64/sshx-server"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/sshx" "/out/x64/sshx-server" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/sshx" "/out/x64/sshx-server"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/sshx" "/out/x64/sshx-server" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/sslh/Dockerfile
+++ b/build/sslh/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/sslh) && cp /tmp/out/sslh /out/x64/sslh \
  && for f in "/out/x64/sslh"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/sslh" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/sslh"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/sslh" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/sslsplit/Dockerfile
+++ b/build/sslsplit/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/sslsplit) && cp /tmp/out/sslsplit /out/x64/sslsplit \
  && for f in "/out/x64/sslsplit"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/sslsplit" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/sslsplit"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/sslsplit" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/strace/Dockerfile
+++ b/build/strace/Dockerfile
@@ -30,6 +30,7 @@ RUN set -ex \
  && for f in "/out/x64/strace"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/strace"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/strace" "/out/arm/strace" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/strace" "/out/arm/strace"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/strace" "/out/arm/strace" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/superfile/Dockerfile
+++ b/build/superfile/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/superfile) && cp /tmp/x64_superfile /out/x64/superfile \
  && mkdir -p $(dirname /out/arm/superfile) && cp /tmp/arm_superfile /out/arm/superfile \
  && test -n "$(ls "/out/x64/superfile" "/out/arm/superfile" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/superfile" "/out/arm/superfile"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/superfile" "/out/arm/superfile" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/suricata/Dockerfile
+++ b/build/suricata/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/suricata) && cp /tmp/out/suricata /out/x64/suricata \
  && for f in "/out/x64/suricata"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/suricata" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/suricata"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/suricata" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/tangd/Dockerfile
+++ b/build/tangd/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/tangd) && cp /tmp/out/tangd /out/x64/tangd \
  && for f in "/out/x64/tangd"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/tangd" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/tangd"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/tangd" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/tcpdump/Dockerfile
+++ b/build/tcpdump/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/tcpdump) && cp /tmp/out/tcpdump /out/x64/tcpdump \
  && for f in "/out/x64/tcpdump"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/tcpdump" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/tcpdump"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/tcpdump" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/termshark/Dockerfile
+++ b/build/termshark/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/termshark) && cp /tmp/x64_termshark /out/x64/termshark \
  && mkdir -p $(dirname /out/arm/termshark) && cp /tmp/arm_termshark /out/arm/termshark \
  && test -n "$(ls "/out/x64/termshark" "/out/arm/termshark" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/termshark" "/out/arm/termshark"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/termshark" "/out/arm/termshark" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/termsvg/Dockerfile
+++ b/build/termsvg/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/termsvg) && cp /tmp/x64_termsvg /out/x64/termsvg \
  && mkdir -p $(dirname /out/arm/termsvg) && cp /tmp/arm_termsvg /out/arm/termsvg \
  && test -n "$(ls "/out/x64/termsvg" "/out/arm/termsvg" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/termsvg" "/out/arm/termsvg"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/termsvg" "/out/arm/termsvg" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/tiny/Dockerfile
+++ b/build/tiny/Dockerfile
@@ -35,6 +35,7 @@ RUN set -ex \
  && for f in "/out/x64/tiny"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/tiny"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/tiny" "/out/arm/tiny" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/tiny" "/out/arm/tiny"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/tiny" "/out/arm/tiny" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/tinyproxy/Dockerfile
+++ b/build/tinyproxy/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/tinyproxy) && cp /tmp/out/tinyproxy /out/x64/tinyproxy \
  && for f in "/out/x64/tinyproxy"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/tinyproxy" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/tinyproxy"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/tinyproxy" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/tmux/Dockerfile
+++ b/build/tmux/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/tmux) && cp /tmp/out/tmux /out/x64/tmux \
  && for f in "/out/x64/tmux"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/tmux" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/tmux"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/tmux" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/tor/Dockerfile
+++ b/build/tor/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/tor) && cp /tmp/out/tor /out/x64/tor \
  && for f in "/out/x64/tor"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/tor" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/tor"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/tor" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/ugrep/Dockerfile
+++ b/build/ugrep/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/ugrep) && cp /tmp/out/ugrep /out/x64/ugrep \
  && for f in "/out/x64/ugrep"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/ugrep" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/ugrep"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/ugrep" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/vi/Dockerfile
+++ b/build/vi/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/vi) && cp /tmp/out/vi /out/x64/vi \
  && for f in "/out/x64/vi"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/vi" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/vi"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/vi" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/vim/Dockerfile
+++ b/build/vim/Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/vim) && cp /tmp/out/vim /out/x64/vim \
  && for f in "/out/x64/vim"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/vim" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/vim"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/vim" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/wg-go/Dockerfile
+++ b/build/wg-go/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/wg-go) && cp /tmp/x64_wg-go /out/x64/wg-go \
  && mkdir -p $(dirname /out/arm/wg-go) && cp /tmp/arm_wg-go /out/arm/wg-go \
  && test -n "$(ls "/out/x64/wg-go" "/out/arm/wg-go" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/wg-go" "/out/arm/wg-go"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/wg-go" "/out/arm/wg-go" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/wg/Dockerfile
+++ b/build/wg/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/wg) && cp /tmp/out/wg /out/x64/wg \
  && for f in "/out/x64/wg"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/wg" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/wg"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/wg" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/wireshark/Dockerfile
+++ b/build/wireshark/Dockerfile
@@ -30,6 +30,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/tfshark) && cp /tmp/out/tfshark /out/x64/tfshark \
  && for f in "/out/x64/tshark" "/out/x64/dumpcap" "/out/x64/editcap" "/out/x64/mergecap" "/out/x64/capinfos" "/out/x64/captype" "/out/x64/rawshark" "/out/x64/text2pcap" "/out/x64/randpkt" "/out/x64/reordercap" "/out/x64/sharkd" "/out/x64/dftest" "/out/x64/tfshark"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/tshark" "/out/x64/dumpcap" "/out/x64/editcap" "/out/x64/mergecap" "/out/x64/capinfos" "/out/x64/captype" "/out/x64/rawshark" "/out/x64/text2pcap" "/out/x64/randpkt" "/out/x64/reordercap" "/out/x64/sharkd" "/out/x64/dftest" "/out/x64/tfshark" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/tshark" "/out/x64/dumpcap" "/out/x64/editcap" "/out/x64/mergecap" "/out/x64/capinfos" "/out/x64/captype" "/out/x64/rawshark" "/out/x64/text2pcap" "/out/x64/randpkt" "/out/x64/reordercap" "/out/x64/sharkd" "/out/x64/dftest" "/out/x64/tfshark"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/tshark" "/out/x64/dumpcap" "/out/x64/editcap" "/out/x64/mergecap" "/out/x64/capinfos" "/out/x64/captype" "/out/x64/rawshark" "/out/x64/text2pcap" "/out/x64/randpkt" "/out/x64/reordercap" "/out/x64/sharkd" "/out/x64/dftest" "/out/x64/tfshark" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/xsv/Dockerfile
+++ b/build/xsv/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/xsv) && cp /tmp/x64_xsv /out/x64/xsv \
  && for f in "/out/x64/xsv"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/xsv" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/xsv"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/xsv" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/xxd/Dockerfile
+++ b/build/xxd/Dockerfile
@@ -25,6 +25,7 @@ RUN set -ex \
  && for f in "/out/x64/xxd"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && for f in "/out/arm/xxd"; do file "$f" | grep -q ELF && arm-linux-musleabihf-strip "$f" || true; done \
  && test -n "$(ls "/out/x64/xxd" "/out/arm/xxd" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/xxd" "/out/arm/xxd"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/xxd" "/out/arm/xxd" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/yq/Dockerfile
+++ b/build/yq/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/yq) && cp /tmp/x64_yq /out/x64/yq \
  && mkdir -p $(dirname /out/arm/yq) && cp /tmp/arm_yq /out/arm/yq \
  && test -n "$(ls "/out/x64/yq" "/out/arm/yq" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/yq" "/out/arm/yq"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/yq" "/out/arm/yq" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/zellij/Dockerfile
+++ b/build/zellij/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/zellij) && cp /tmp/x64_zellij /out/x64/zellij \
  && for f in "/out/x64/zellij"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/zellij" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/zellij"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/zellij" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/zenith/Dockerfile
+++ b/build/zenith/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/zenith) && cp /tmp/x64_zenith /out/x64/zenith \
  && for f in "/out/x64/zenith"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/zenith" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/zenith"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/zenith" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/build/zmap/Dockerfile
+++ b/build/zmap/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex \
  && mkdir -p $(dirname /out/x64/zgrab2) && cp /tmp/out/zgrab2 /out/x64/zgrab2 \
  && for f in "/out/x64/zmap" "/out/x64/ztee" "/out/x64/zgrab2"; do file "$f" | grep -q ELF && strip "$f" || true; done \
  && test -n "$(ls "/out/x64/zmap" "/out/x64/ztee" "/out/x64/zgrab2" 2>/dev/null | head -1)" || { echo "ERROR: no binaries produced"; exit 1; } \
+ && for f in "/out/x64/zmap" "/out/x64/ztee" "/out/x64/zgrab2"; do file "$f" | grep -q ELF || continue; file "$f" | grep -qE "statically linked|static-pie linked" || { echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }; done \
  && ( upx -q --best --lzma "/out/x64/zmap" "/out/x64/ztee" "/out/x64/zgrab2" || echo 'upx failed; shipping unpacked' )
 
 FROM alpine:3.20

--- a/scripts/gen_dockerfiles.py
+++ b/scripts/gen_dockerfiles.py
@@ -302,6 +302,17 @@ def _collect_and_pack(pairs, r):
     if allbins:
         steps.append(f'test -n "$(ls {_q(allbins)} 2>/dev/null | head -1)" || {{ echo "ERROR: no binaries produced"; exit 1; }}')
 
+    # Everything here ships as a single static file. Several tools quietly did
+    # not: dropbear's hardening adds -Wl,-pie, which beats -static; dsvpn and
+    # icmptunnel link through CFLAGS; tor was never told to link statically.
+    # A dynamic binary is useless on the targets this repo exists for, so the
+    # build fails rather than shipping one. Checked before UPX, which hides it.
+    if allbins:
+        steps.append(
+            f'for f in {_q(allbins)}; do file "$f" | grep -q ELF || continue; '
+            f'file "$f" | grep -qE "statically linked|static-pie linked" || '
+            f'{{ echo "ERROR: $f is dynamically linked"; file "$f"; exit 1; }}; done')
+
     if r.get("pack", True):
         # UPX is multi-arch; keep non-fatal only for genuinely unpackable
         # binaries (already-packed or format unsupported), but if nothing was


### PR DESCRIPTION
Everything here ships as one static file — that is the point of the repo. Several
tools quietly did not, and each was found by hand in #21 after shipping broken for
who knows how long:

- `dropbear` — hardening adds `-Wl,-pie`, which beats `-static`
- `dsvpn`, `icmptunnel` — Makefiles link through `CFLAGS`, so `LDFLAGS=-static` did nothing
- `tor` — configure was never told to link statically
- `zgrab2` — `go install` defaults to cgo when gcc is present
- `suricata` — libtool only honours `-all-static`

Every Dockerfile now checks its outputs immediately before UPX packs them — the last
moment linkage is still visible — and fails the build instead of shipping something
the target cannot run. Non-ELF outputs (wireshark's `text2pcap` wrapper) are skipped,
and `static-pie` counts as static.

Verified by reverting dsvpn's fix:

```
ERROR: /out/x64/dsvpn is dynamically linked
```

and by a clean `jq` build with the guard in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)