### PR TITLE
Find the artifacts when a bump has one tool

### DIFF
--- a/scripts/apply_bump.sh
+++ b/scripts/apply_bump.sh
@@ -59,9 +59,20 @@ while [ $i -lt $N ]; do
     LATEST=$($YQ -r ".outdated[$i].latest" "$OUTDATED")
     i=$((i+1))
 
-    XDIR="$DIST/bt-$TOOL/x64"
-    ADIR="$DIST/bt-$TOOL/arm"
-    [ -d "$XDIR" ] || { echo "skip $TOOL (no artifacts)"; continue; }
+    # download-artifact drops the per-artifact directory when a pattern matches
+    # exactly one artifact, so a single-tool bump lands in <dist>/x64 instead of
+    # <dist>/bt-<tool>/x64. That flat layout is only unambiguous when this run
+    # bumped one tool.
+    ROOTDIR=""
+    for CAND in "$DIST/bt-$TOOL" "$DIST/$TOOL"; do
+        [ -d "$CAND/x64" ] && { ROOTDIR=$CAND; break; }
+    done
+    if [ -z "$ROOTDIR" ] && [ "$N" = 1 ] && [ -d "$DIST/x64" ]; then
+        ROOTDIR=$DIST
+    fi
+    [ -n "$ROOTDIR" ] || { echo "skip $TOOL (no artifacts)"; continue; }
+    XDIR="$ROOTDIR/x64"
+    ADIR="$ROOTDIR/arm"
 
     # verify every declared output actually built before touching the repo
     MISSING=0


### PR DESCRIPTION
`actions/download-artifact` drops the per-artifact directory when its pattern matches
exactly one artifact, so a single-tool run lands in `<dist>/x64` rather than
`<dist>/bt-<tool>/x64`.

`apply_bump.sh` looked only for the nested path. The dnsmonster rerun after #25 built
fine, uploaded a 15 MB artifact, then:

```
bumping 1 tools
skip dnsmonster (no artifacts)
nothing changed; no PR
```

— green run, nothing shipped. The 13-tool and 32-tool runs were unaffected, because
multiple artifacts force the subdirectories.

It now tries both layouts, falling back to the flat one only when the run bumped a
single tool, where it is unambiguous. Verified both ways against a scratch tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)