### PR TITLE
Pull nc's C dependencies from debian's pool

### DIFF
--- a/build/nc/Dockerfile
+++ b/build/nc/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 RUN apk add --no-cache build-base git ca-certificates curl upx linux-headers xz bzip2 linux-headers libmd-dev patch
 RUN mkdir -p /src && curl -fsSL --retry 3 --retry-delay 2 "https://salsa.debian.org/debian/netcat-openbsd/-/archive/debian/${VERSION}/netcat-openbsd-debian-${VERSION}.tar.gz" | gunzip -c | tar x -C /src --strip-components=1
 WORKDIR /src
-RUN mkdir -p /libbsd /opt/libbsd && curl -fsSL --retry 3 https://libbsd.freedesktop.org/releases/libbsd-0.12.2.tar.xz | unxz | tar x -C /libbsd --strip-components=1 && cd /libbsd && ./configure --prefix=/opt/libbsd --disable-shared --enable-static && make -j$(nproc) && make install && cd /src && while read -r p; do patch -Np1 < "debian/patches/$p"; done < debian/patches/series && curl -fsSL --retry 3 https://gitlab.alpinelinux.org/alpine/aports/-/raw/master/main/netcat-openbsd/base64.c -o base64.c && curl -fsSL --retry 3 https://gitlab.alpinelinux.org/alpine/aports/-/raw/master/main/netcat-openbsd/b64.patch | patch -Np1 && sed -i '/SRCS=/s;\(.*\);& base64.c;' Makefile
+RUN mkdir -p /libbsd /opt/libbsd && curl -fsSL --retry 3 http://deb.debian.org/debian/pool/main/libb/libbsd/libbsd_0.12.2.orig.tar.xz | unxz | tar x -C /libbsd --strip-components=1 && cd /libbsd && ./configure --prefix=/opt/libbsd --disable-shared --enable-static && make -j$(nproc) && make install && cd /src && while read -r p; do patch -Np1 < "debian/patches/$p"; done < debian/patches/series && curl -fsSL --retry 3 https://gitlab.alpinelinux.org/alpine/aports/-/raw/master/main/netcat-openbsd/base64.c -o base64.c && curl -fsSL --retry 3 https://gitlab.alpinelinux.org/alpine/aports/-/raw/master/main/netcat-openbsd/b64.patch | patch -Np1 && sed -i '/SRCS=/s;\(.*\);& base64.c;' Makefile
 RUN set -ex \
  && mkdir -p /tmp/out \
  && mkdir -p /tmp/out \
@@ -22,9 +22,9 @@ RUN set -ex \
  && mkdir -p /tmp/out-arm \
  && make clean || true \
  && mkdir -p /libmd-arm /libbsd-arm /opt/arm-deps \
- && curl -fsSL --retry 3 https://archive.hadrons.org/software/libmd/libmd-1.1.0.tar.xz | unxz | tar x -C /libmd-arm --strip-components=1 \
+ && curl -fsSL --retry 3 http://deb.debian.org/debian/pool/main/libm/libmd/libmd_1.1.0.orig.tar.xz | unxz | tar x -C /libmd-arm --strip-components=1 \
  && cd /libmd-arm && ./configure --host=arm-linux-musleabihf --prefix=/opt/arm-deps --disable-shared --enable-static && make -j$(nproc) && make install && cd /src \
- && curl -fsSL --retry 3 https://libbsd.freedesktop.org/releases/libbsd-0.12.2.tar.xz | unxz | tar x -C /libbsd-arm --strip-components=1 \
+ && curl -fsSL --retry 3 http://deb.debian.org/debian/pool/main/libb/libbsd/libbsd_0.12.2.orig.tar.xz | unxz | tar x -C /libbsd-arm --strip-components=1 \
  && cd /libbsd-arm && ./configure --host=arm-linux-musleabihf --prefix=/opt/arm-deps --disable-shared --enable-static CPPFLAGS=-I/opt/arm-deps/include LDFLAGS=-L/opt/arm-deps/lib && make -j$(nproc) && make install && cd /src \
  && make CC=arm-linux-musleabihf-gcc CFLAGS='-O2 -static -DIPTOS_DSCP_VA=0xb0 -I/opt/arm-deps/include' LDFLAGS='-static -L/opt/arm-deps/lib' LIBS='-lbsd -lmd' \
  && mkdir -p /tmp/out-arm && cp nc /tmp/out-arm/

--- a/scripts/recipes_c.py
+++ b/scripts/recipes_c.py
@@ -536,13 +536,16 @@ RECIPES["tor"] = dict(
 # no recipe at all, the last dynamic binary in the repo.
 _LIBBSD = "0.12.2"
 _LIBMD = "1.1.0"
+# upstream libbsd answers GitHub runners with HTTP 418; debian's pool serves the
+# same tarballs, and this build already pulls netcat from there
+_DEB_POOL = "http://deb.debian.org/debian/pool/main"
 _APORTS = ("https://gitlab.alpinelinux.org/alpine/aports/-/raw/master/"
            "main/netcat-openbsd")
 _NC_PRE = [
     # libbsd carries strtonum/arc4random for the OpenBSD source; alpine ships
     # it shared-only, so build a static one
     "mkdir -p /libbsd /opt/libbsd",
-    f"curl -fsSL --retry 3 https://libbsd.freedesktop.org/releases/libbsd-{_LIBBSD}.tar.xz "
+    f"curl -fsSL --retry 3 {_DEB_POOL}/libb/libbsd/libbsd_{_LIBBSD}.orig.tar.xz "
     "| unxz | tar x -C /libbsd --strip-components=1",
     "cd /libbsd && ./configure --prefix=/opt/libbsd --disable-shared --enable-static "
     "&& make -j$(nproc) && make install && cd /src",
@@ -570,11 +573,11 @@ RECIPES["nc"] = dict(
     # ARM needs its own libmd and libbsd; alpine cross-ships neither
     arm_build=["make clean || true",
                "mkdir -p /libmd-arm /libbsd-arm /opt/arm-deps",
-               f"curl -fsSL --retry 3 https://archive.hadrons.org/software/libmd/libmd-{_LIBMD}.tar.xz "
+               f"curl -fsSL --retry 3 {_DEB_POOL}/libm/libmd/libmd_{_LIBMD}.orig.tar.xz "
                "| unxz | tar x -C /libmd-arm --strip-components=1",
                "cd /libmd-arm && ./configure --host=arm-linux-musleabihf --prefix=/opt/arm-deps "
                "--disable-shared --enable-static && make -j$(nproc) && make install && cd /src",
-               f"curl -fsSL --retry 3 https://libbsd.freedesktop.org/releases/libbsd-{_LIBBSD}.tar.xz "
+               f"curl -fsSL --retry 3 {_DEB_POOL}/libb/libbsd/libbsd_{_LIBBSD}.orig.tar.xz "
                "| unxz | tar x -C /libbsd-arm --strip-components=1",
                "cd /libbsd-arm && ./configure --host=arm-linux-musleabihf --prefix=/opt/arm-deps "
                "--disable-shared --enable-static CPPFLAGS=-I/opt/arm-deps/include "


### PR DESCRIPTION
The runner got `curl: (22) The requested URL returned error: 418` from
libbsd.freedesktop.org, so the first `nc` build failed in CI while passing locally.

Debian's pool serves the same libbsd and libmd tarballs, and the build already
fetches netcat from it. Rebuilt clean locally against the new URLs — x64 and ARM both
static, both smoke tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)