### PR TITLE
Vendor nc's base64.c instead of fetching it

### DIFF
--- a/build/nc/Dockerfile
+++ b/build/nc/Dockerfile
@@ -7,7 +7,8 @@ ARG VERSION
 RUN apk add --no-cache build-base git ca-certificates curl upx linux-headers xz bzip2 linux-headers libmd-dev patch
 RUN mkdir -p /src && curl -fsSL --retry 3 --retry-delay 2 "https://salsa.debian.org/debian/netcat-openbsd/-/archive/debian/${VERSION}/netcat-openbsd-debian-${VERSION}.tar.gz" | gunzip -c | tar x -C /src --strip-components=1
 WORKDIR /src
-RUN mkdir -p /libbsd /opt/libbsd && curl -fsSL --retry 3 http://deb.debian.org/debian/pool/main/libb/libbsd/libbsd_0.12.2.orig.tar.xz | unxz | tar x -C /libbsd --strip-components=1 && cd /libbsd && ./configure --prefix=/opt/libbsd --disable-shared --enable-static && make -j$(nproc) && make install && cd /src && while read -r p; do patch -Np1 < "debian/patches/$p"; done < debian/patches/series && curl -fsSL --retry 3 https://gitlab.alpinelinux.org/alpine/aports/-/raw/master/main/netcat-openbsd/base64.c -o base64.c && curl -fsSL --retry 3 https://gitlab.alpinelinux.org/alpine/aports/-/raw/master/main/netcat-openbsd/b64.patch | patch -Np1 && sed -i '/SRCS=/s;\(.*\);& base64.c;' Makefile
+COPY base64.c /src/base64.c
+RUN mkdir -p /libbsd /opt/libbsd && curl -fsSL --retry 3 http://deb.debian.org/debian/pool/main/libb/libbsd/libbsd_0.12.2.orig.tar.xz | unxz | tar x -C /libbsd --strip-components=1 && cd /libbsd && ./configure --prefix=/opt/libbsd --disable-shared --enable-static && make -j$(nproc) && make install && cd /src && while read -r p; do patch -Np1 < "debian/patches/$p"; done < debian/patches/series && sed -i '/^int[[:space:]]*remote_connect(/i int b64_ntop(const unsigned char *, size_t, char *, size_t);' socks.c && sed -i '/SRCS=/s;\(.*\);& base64.c;' Makefile
 RUN set -ex \
  && mkdir -p /tmp/out \
  && mkdir -p /tmp/out \

--- a/build/nc/base64.c
+++ b/build/nc/base64.c
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 1996-1999 by Internet Software Consortium.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ * ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+ * CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+ * PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ * ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ * SOFTWARE.
+ */
+
+/*
+ * Portions Copyright (c) 1995 by International Business Machines, Inc.
+ *
+ * International Business Machines, Inc. (hereinafter called IBM) grants
+ * permission under its copyrights to use, copy, modify, and distribute this
+ * Software with or without fee, provided that the above copyright notice and
+ * all paragraphs of this notice appear in all copies, and that the name of IBM
+ * not be used in connection with the marketing of any product incorporating
+ * the Software or modifications thereof, without specific, written prior
+ * permission.
+ *
+ * To the extent it has a right to do so, IBM grants an immunity from suit
+ * under its patents, if any, for the use, sale or manufacture of products to
+ * the extent that such products are used for performing Domain Name System
+ * dynamic updates in TCP/IP networks by means of the Software.  No immunity is
+ * granted for any product per se or for any other function of any product.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", AND IBM DISCLAIMS ALL WARRANTIES,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.  IN NO EVENT SHALL IBM BE LIABLE FOR ANY SPECIAL,
+ * DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE, EVEN
+ * IF IBM IS APPRISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ */
+
+#if !defined(LINT) && !defined(CODECENTER)
+static const char rcsid[] = "$BINDId: base64.c,v 8.7 1999/10/13 16:39:33 vixie Exp $";
+#endif /* not lint */
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <arpa/nameser.h>
+
+#include <ctype.h>
+#include <resolv.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#define Assert(Cond) if (!(Cond)) abort()
+
+static const char Base64[] =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char Pad64 = '=';
+
+/* (From RFC1521 and draft-ietf-dnssec-secext-03.txt)
+   The following encoding technique is taken from RFC 1521 by Borenstein
+   and Freed.  It is reproduced here in a slightly edited form for
+   convenience.
+
+   A 65-character subset of US-ASCII is used, enabling 6 bits to be
+   represented per printable character. (The extra 65th character, "=",
+   is used to signify a special processing function.)
+
+   The encoding process represents 24-bit groups of input bits as output
+   strings of 4 encoded characters. Proceeding from left to right, a
+   24-bit input group is formed by concatenating 3 8-bit input groups.
+   These 24 bits are then treated as 4 concatenated 6-bit groups, each
+   of which is translated into a single digit in the base64 alphabet.
+
+   Each 6-bit group is used as an index into an array of 64 printable
+   characters. The character referenced by the index is placed in the
+   output string.
+
+                         Table 1: The Base64 Alphabet
+
+      Value Encoding  Value Encoding  Value Encoding  Value Encoding
+          0 A            17 R            34 i            51 z
+          1 B            18 S            35 j            52 0
+          2 C            19 T            36 k            53 1
+          3 D            20 U            37 l            54 2
+          4 E            21 V            38 m            55 3
+          5 F            22 W            39 n            56 4
+          6 G            23 X            40 o            57 5
+          7 H            24 Y            41 p            58 6
+          8 I            25 Z            42 q            59 7
+          9 J            26 a            43 r            60 8
+         10 K            27 b            44 s            61 9
+         11 L            28 c            45 t            62 +
+         12 M            29 d            46 u            63 /
+         13 N            30 e            47 v
+         14 O            31 f            48 w         (pad) =
+         15 P            32 g            49 x
+         16 Q            33 h            50 y
+
+   Special processing is performed if fewer than 24 bits are available
+   at the end of the data being encoded.  A full encoding quantum is
+   always completed at the end of a quantity.  When fewer than 24 input
+   bits are available in an input group, zero bits are added (on the
+   right) to form an integral number of 6-bit groups.  Padding at the
+   end of the data is performed using the '=' character.
+
+   Since all base64 input is an integral number of octets, only the
+         -------------------------------------------------
+   following cases can arise:
+
+       (1) the final quantum of encoding input is an integral
+           multiple of 24 bits; here, the final unit of encoded
+	   output will be an integral multiple of 4 characters
+	   with no "=" padding,
+       (2) the final quantum of encoding input is exactly 8 bits;
+           here, the final unit of encoded output will be two
+	   characters followed by two "=" padding characters, or
+       (3) the final quantum of encoding input is exactly 16 bits;
+           here, the final unit of encoded output will be three
+	   characters followed by one "=" padding character.
+   */
+
+int
+b64_ntop(const uint8_t* src, size_t srclength, char* target, size_t targsize)
+{
+	size_t datalength = 0;
+	uint8_t input[3];
+	uint8_t output[4];
+	size_t i;
+
+	while (2 < srclength) {
+		input[0] = *src++;
+		input[1] = *src++;
+		input[2] = *src++;
+		srclength -= 3;
+
+		output[0] = input[0] >> 2;
+		output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+		output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+		output[3] = input[2] & 0x3f;
+		Assert(output[0] < 64);
+		Assert(output[1] < 64);
+		Assert(output[2] < 64);
+		Assert(output[3] < 64);
+
+		if (datalength + 4 > targsize)
+			return (-1);
+		target[datalength++] = Base64[output[0]];
+		target[datalength++] = Base64[output[1]];
+		target[datalength++] = Base64[output[2]];
+		target[datalength++] = Base64[output[3]];
+	}
+
+	/* Now we worry about padding. */
+	if (0 != srclength) {
+		/* Get what's left. */
+		input[0] = input[1] = input[2] = '\0';
+		for (i = 0; i < srclength; i++)
+			input[i] = *src++;
+
+		output[0] = input[0] >> 2;
+		output[1] = ((input[0] & 0x03) << 4) + (input[1] >> 4);
+		output[2] = ((input[1] & 0x0f) << 2) + (input[2] >> 6);
+		Assert(output[0] < 64);
+		Assert(output[1] < 64);
+		Assert(output[2] < 64);
+
+		if (datalength + 4 > targsize)
+			return (-1);
+		target[datalength++] = Base64[output[0]];
+		target[datalength++] = Base64[output[1]];
+		if (srclength == 1)
+			target[datalength++] = Pad64;
+		else
+			target[datalength++] = Base64[output[2]];
+		target[datalength++] = Pad64;
+	}
+	if (datalength >= targsize)
+		return (-1);
+	target[datalength] = '\0';	/* Returned value doesn't count \0. */
+	return (datalength);
+}
+
+/* skips all whitespace anywhere.
+   converts characters, four at a time, starting at (or after)
+   src from base - 64 numbers into three 8 bit bytes in the target area.
+   it returns the number of data bytes stored at the target, or -1 on error.
+ */
+
+int b64_pton(const char* src, uint8_t* target, size_t targsize)
+{
+	int tarindex, state, ch;
+	char *pos;
+
+	state = 0;
+	tarindex = 0;
+
+	while ((ch = *src++) != '\0') {
+		if (isspace(ch))	/* Skip whitespace anywhere. */
+			continue;
+
+		if (ch == Pad64)
+			break;
+
+		pos = strchr(Base64, ch);
+		if (pos == 0) 		/* A non-base64 character. */
+			return (-1);
+
+		switch (state) {
+		case 0:
+			if (target) {
+				if ((size_t)tarindex >= targsize)
+					return (-1);
+				target[tarindex] = (pos - Base64) << 2;
+			}
+			state = 1;
+			break;
+		case 1:
+			if (target) {
+				if ((size_t)tarindex + 1 >= targsize)
+					return (-1);
+				target[tarindex]   |=  (pos - Base64) >> 4;
+				target[tarindex+1]  = ((pos - Base64) & 0x0f)
+							<< 4 ;
+			}
+			tarindex++;
+			state = 2;
+			break;
+		case 2:
+			if (target) {
+				if ((size_t)tarindex + 1 >= targsize)
+					return (-1);
+				target[tarindex]   |=  (pos - Base64) >> 2;
+				target[tarindex+1]  = ((pos - Base64) & 0x03)
+							<< 6;
+			}
+			tarindex++;
+			state = 3;
+			break;
+		case 3:
+			if (target) {
+				if ((size_t)tarindex >= targsize)
+					return (-1);
+				target[tarindex] |= (pos - Base64);
+			}
+			tarindex++;
+			state = 0;
+			break;
+		default:
+			abort();
+		}
+	}
+
+	/*
+	 * We are done decoding Base-64 chars.  Let's see if we ended
+	 * on a byte boundary, and/or with erroneous trailing characters.
+	 */
+
+	if (ch == Pad64) {		/* We got a pad char. */
+		ch = *src++;		/* Skip it, get next. */
+		switch (state) {
+		case 0:		/* Invalid = in first position */
+		case 1:		/* Invalid = in second position */
+			return (-1);
+
+		case 2:		/* Valid, means one byte of info */
+			/* Skip any number of spaces. */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (!isspace(ch))
+					break;
+			/* Make sure there is another trailing = sign. */
+			if (ch != Pad64)
+				return (-1);
+			ch = *src++;		/* Skip the = */
+			/* Fall through to "single trailing =" case. */
+			/* FALLTHROUGH */
+
+		case 3:		/* Valid, means two bytes of info */
+			/*
+			 * We know this char is an =.  Is there anything but
+			 * whitespace after it?
+			 */
+			for ((void)NULL; ch != '\0'; ch = *src++)
+				if (!isspace(ch))
+					return (-1);
+
+			/*
+			 * Now make sure for cases 2 and 3 that the "extra"
+			 * bits that slopped past the last full byte were
+			 * zeros.  If we don't check them, they become a
+			 * subliminal channel.
+			 */
+			if (target && target[tarindex] != 0)
+				return (-1);
+		}
+	} else {
+		/*
+		 * We ended by seeing the end of the string.  Make sure we
+		 * have no partial bytes lying around.
+		 */
+		if (state != 0)
+			return (-1);
+	}
+
+	return (tarindex);
+}
+

--- a/scripts/gen_dockerfiles.py
+++ b/scripts/gen_dockerfiles.py
@@ -126,6 +126,10 @@ def go_recipe(name, r):
         else:
             b.append(f"RUN git clone --depth 1 --branch {r.get('extra_tag_prefix', '')}${{VERSION}} {u} /src/{d}")
     b.append("WORKDIR /src")
+    # files vendored next to the Dockerfile, for sources no build should have
+    # to fetch at build time
+    for f in r.get("files", []):
+        b.append(f"COPY {f} /src/{f}")
     if r.get("env"):
         for k, v in r["env"].items():
             b.append(f'ENV {k}="{v}"')
@@ -196,6 +200,10 @@ def rust_recipe(name, r):
     else:
         b.append("RUN apk add --no-cache git ca-certificates upx musl-dev perl make")
     b += [fetch_lines(r), "WORKDIR /src"]
+    # files vendored next to the Dockerfile, for sources no build should have
+    # to fetch at build time
+    for f in r.get("files", []):
+        b.append(f"COPY {f} /src/{f}")
     if r.get("env"):
         for k, v in r["env"].items():
             b.append(f'ENV {k}="{v}"')
@@ -254,6 +262,10 @@ def c_recipe(name, r):
         fetch_lines(r),
         "WORKDIR /src",
     ]
+    # files vendored next to the Dockerfile, for sources no build should have
+    # to fetch at build time
+    for f in r.get("files", []):
+        b.append(f"COPY {f} /src/{f}")
     if r.get("env"):
         for k, v in r["env"].items():
             b.append(f'ENV {k}="{v}"')

--- a/scripts/recipes_c.py
+++ b/scripts/recipes_c.py
@@ -539,8 +539,6 @@ _LIBMD = "1.1.0"
 # upstream libbsd answers GitHub runners with HTTP 418; debian's pool serves the
 # same tarballs, and this build already pulls netcat from there
 _DEB_POOL = "http://deb.debian.org/debian/pool/main"
-_APORTS = ("https://gitlab.alpinelinux.org/alpine/aports/-/raw/master/"
-           "main/netcat-openbsd")
 _NC_PRE = [
     # libbsd carries strtonum/arc4random for the OpenBSD source; alpine ships
     # it shared-only, so build a static one
@@ -551,9 +549,11 @@ _NC_PRE = [
     "&& make -j$(nproc) && make install && cd /src",
     # debian keeps the linux port as a quilt series
     'while read -r p; do patch -Np1 < "debian/patches/$p"; done < debian/patches/series',
-    # the port calls b64_ntop, which musl has no equivalent of
-    f"curl -fsSL --retry 3 {_APORTS}/base64.c -o base64.c",
-    f"curl -fsSL --retry 3 {_APORTS}/b64.patch | patch -Np1",
+    # the port calls b64_ntop, which musl has no equivalent of. base64.c is
+    # vendored in build/nc/: the runner could not reach the distro git host it
+    # used to come from, and a build should not depend on one being up
+    r"sed -i '/^int[[:space:]]*remote_connect(/i "
+    r"int b64_ntop(const unsigned char *, size_t, char *, size_t);' socks.c",
     r"""sed -i '/SRCS=/s;\(.*\);& base64.c;' Makefile""",
 ]
 # IPTOS_DSCP_VA is a linux/glibc define musl's netinet/ip.h lacks
@@ -565,6 +565,7 @@ RECIPES["nc"] = dict(
             "debian/{v}/netcat-openbsd-debian-{v}.tar.gz",
     bins=[("nc", "")],
     pkgs=["linux-headers", "libmd-dev", "patch"],
+    files=["base64.c"],
     pre=_NC_PRE,
     build=["mkdir -p /tmp/out",
            f"make CFLAGS='{_NC_CFLAGS} -I/opt/libbsd/include' "


### PR DESCRIPTION
Second CI-only failure on the same build: the runner could not reach
gitlab.alpinelinux.org, where `base64.c` and `b64.patch` were being fetched from.

```
curl: (28) Failed to connect to gitlab.alpinelinux.org port 443 after 132505 ms
```

`base64.c` (ISC, from BIND, unchanged) now lives in `build/nc/` and is copied into the
build. The one-line prototype `b64.patch` supplied is a `sed` instead, so there is no
patch file to carry.

Recipes gained a `files` key for this — sources that belong next to the Dockerfile
rather than behind someone else's uptime.

Rebuilt clean locally: x64 and ARM both static, both smoke tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)